### PR TITLE
Fix lifesteal crash on Mac/Linux

### DIFF
--- a/EpicLoot/MagicItemEffects/Paralyze.cs
+++ b/EpicLoot/MagicItemEffects/Paralyze.cs
@@ -19,20 +19,10 @@ namespace EpicLoot.MagicItemEffects
 
     public static class Paralyze
     {
-        //public virtual void OnDamaged(HitData hit)
-        [HarmonyPatch(typeof(Character), nameof(Character.OnDamaged))]
-        public static class Paralyze_Character_OnDamaged_Patch
+        [HarmonyPatch(typeof(Character), nameof(Character.Damage))]
+        public static class Paralyze_Character_Damage_Patch
         {
-            public static void Postfix(Character __instance, HitData hit)
-            {
-                OnDamaged(__instance, hit);
-            }
-        }
-
-        [HarmonyPatch(typeof(Humanoid), nameof(Humanoid.OnDamaged))]
-        public static class Paralyze_Humanoid_OnDamaged_Patch
-        {
-            public static void Postfix(Character __instance, HitData hit)
+            static void Postfix(Character __instance, HitData hit)
             {
                 OnDamaged(__instance, hit);
             }


### PR DESCRIPTION
Fixes issue #137

Patching virtual/empty method `Character.OnDamaged()` causes crashes on linux (most likely also on mac since both use mono).
Original code was also patching `Humanoid.OnDamaged()` which is Character method override.

This patch makes Harmony patch of non-virtual `Character.Damage()` instead of above two methods.

