### PR TITLE
[EAQS] Stack to quick bar and handle item pickup when main inventory full

### DIFF
--- a/EquipmentAndQuickSlots/ExtendedInventory.cs
+++ b/EquipmentAndQuickSlots/ExtendedInventory.cs
@@ -86,6 +86,48 @@ namespace EquipmentAndQuickSlots
             return result;
         }
 
+        public Vector2i OverrideFindEmptySlot(bool topFirst)
+        {
+            CallBase = true;
+            Vector2i result = new Vector2i(-1, -1);
+            foreach (var inventory in _inventories)
+            {
+                if (!inventory.CountAsEmptySlots(_player))
+                {
+                    continue;
+                }
+
+                result = inventory.FindEmptySlot(topFirst);
+                if (result.x != -1)
+                {
+                    break;
+                }
+            }
+
+            CallBase = false;
+            return result;
+        }
+
+        public ItemDrop.ItemData OverrideFindFreeStackItem(string name, int quality)
+        {
+            ItemDrop.ItemData result = null;
+            foreach (var inventory in _inventories)
+            {
+                if (!inventory.CountAsEmptySlots(_player))
+                {
+                    continue;
+                }
+
+                result = inventory.FindFreeStackItem(name, quality);
+                if (result != null)
+                {
+                    break;
+                }
+            }
+
+            return result;
+        }
+
         public bool OverrideContainsItem(ItemDrop.ItemData item)
         {
             CallBase = true;

--- a/EquipmentAndQuickSlots/Humanoid_Patch.cs
+++ b/EquipmentAndQuickSlots/Humanoid_Patch.cs
@@ -104,7 +104,16 @@ namespace EquipmentAndQuickSlots
                             continue;
                         }
 
+                        var extended = destInventory.Extended();
+                        if (extended != null)
+                        {
+                            extended.CallBase = true;
+                        }
                         var emptySlot = destInventory.FindEmptySlot(false);
+                        if (extended != null)
+                        {
+                            extended.CallBase = false;
+                        }
                         if (emptySlot.x >= 0 && emptySlot.y >= 0)
                         {
                             moved = true;


### PR DESCRIPTION
Now items will stack to the inventory first (if an item is below maximum stack), then the quick slot bar, and if any remain will be added to inventory or (if full) quick slot bar.