### PR TITLE
[EAQS] Fix equipment not re-equipping when trying to unequip with full inventory.

### DIFF
--- a/EquipmentAndQuickSlots/Humanoid_Patch.cs
+++ b/EquipmentAndQuickSlots/Humanoid_Patch.cs
@@ -123,7 +123,7 @@ namespace EquipmentAndQuickSlots
                         }
                         else
                         {
-                            item.m_equiped = true;
+                            player.EquipItem(item, false);
                             player.Message(MessageHud.MessageType.Center, "Could not unequip, inventory full");
                         }
                     }


### PR DESCRIPTION
Upon trying to unequip an item with a full inventory the item stays in its slot, unequipped, and you can't interact with it until restarting.