### PR TITLE
Resolve NRE in ExecutionerCheckDamage_Character_Damage_Patch

### DIFF
--- a/EpicLoot/MagicItemEffects/Executioner.cs
+++ b/EpicLoot/MagicItemEffects/Executioner.cs
@@ -33,7 +33,7 @@ namespace EpicLoot.MagicItemEffects
 		[UsedImplicitly]
 		private static void Prefix(Character __instance, HitData hit)
 		{
-			if (hit.GetAttacker() is Player player)
+			if (hit?.GetAttacker() is Player player)
 			{
 				if (__instance.GetComponent<ZNetView>().GetZDO().GetBool("epic loot executioner flag " + player.GetZDO().m_uid))
 				{


### PR DESCRIPTION
This resolves an NRE in ExecutionerCheckDamage_Character_Damage_Patch when "**HitData hit**" is null.