### PR TITLE
Update m_totalWeight with weight from all player containers.

### DIFF
--- a/EquipmentAndQuickSlots/ExtendedInventory.cs
+++ b/EquipmentAndQuickSlots/ExtendedInventory.cs
@@ -136,10 +136,26 @@ namespace EquipmentAndQuickSlots
             return result;
         }
 
-        public float OverrideGetTotalWeight()
+        public float OverrideGetTotalWeight(bool isPlayerInv = true)
         {
             CallBase = true;
             var result = _inventories.Sum(x => x.GetTotalWeight());
+
+            var totalWeight = 0f;
+
+            if (isPlayerInv) //Skip the full countainer counting when we are not checking Players inventory
+            {
+                foreach (var inventory in _inventories)
+                {
+                    foreach (var itemData in inventory.m_inventory)
+                    {
+                        totalWeight += itemData.GetWeight();
+
+                    }
+                }
+                result = totalWeight;
+            }
+
             CallBase = false;
             return result;
         }
@@ -332,11 +348,27 @@ namespace EquipmentAndQuickSlots
             return (totalCount / totalSlots * 100.0f);
         }
 
-        public void OverrideUpdateTotalWeight()
+        public float OverrideUpdateTotalWeight(bool isPlayerInv = true)
         {
             CallBase = true;
             _inventories.ForEach(x => x.UpdateTotalWeight());
+
+            var totalWeight = 0f;
+
+            if (isPlayerInv) //Skip the full countainer counting when we are not checking Players inventory
+            {
+                foreach (var inventory in _inventories)
+                {
+                    foreach (var itemData in inventory.m_inventory)
+                    {
+                        totalWeight += itemData.GetWeight();
+
+                    }
+                }
+            }
+
             CallBase = false;
+            return totalWeight;
         }
 
         public bool OverrideIsTeleportable()

--- a/EquipmentAndQuickSlots/Inventory_Patch.cs
+++ b/EquipmentAndQuickSlots/Inventory_Patch.cs
@@ -533,7 +533,8 @@ namespace EquipmentAndQuickSlots
             
         }
     }
-   
+
+    //  public float GetTotalWeight() => this.m_totalWeight;
     [HarmonyPatch(typeof(Inventory), "GetTotalWeight")]
     public static class Inventory_GetTotalWeight_Patch
     {


### PR DESCRIPTION
UpdateTotalWeight + extended call: check the weight of every item in every inventories if updating players inventory
GetTotalWeight + extended call: check the weight of every item in every inventories if updating players inventory

RemoveAll Postfix: Do UpdateTotalWeight()
RemoveItem Postfix: Do UpdateTotalWeight()
RemoveOneItem Postfix: Do UpdateTotalWeight()
AddItem Postfix: Do UpdateTotalWeight()

UpdateTotalWeight and GetTotalWeight seems redundant, however, fixing GetTotalWeight was required to get the correct weight before items are moved/removed/added to the inventory.
Did not want to run __instance.UpdateTotalWeight() at GetTotalWeight.Postfix as the method are called with Humanoid.AutoPickup() for each Itemdrop nearby. The extended call seems to be ignored when called from Humanoid.AutoPickup().
Remove GetTotalWeight patch completely, and add a separate call to UpdateTotalWeight() from OnSpawn() or any other methods that are RunOnce could also solve the initial weight.
The only issue we are able to find with this fix after running on multiple clients on dedicated server for almost a week is that when you login (spawn) on top of loot, the game picks it up before it realize your at weight limit.
I do not guarantee that my fix is perfomance effective, feel free to improve it further.