### PR TITLE
Adds a new Requirement type "RequiredEffectTypes"

### DIFF
--- a/EpicLoot/MagicItem.cs
+++ b/EpicLoot/MagicItem.cs
@@ -108,6 +108,11 @@ namespace EpicLoot
             return Effects.Any(x => effectTypes.Contains(x.EffectType));
         }
 
+        public bool HasAllEffect(IEnumerable<string> effectTypes)
+        {
+            return Effects.All(x => effectTypes.Contains(x.EffectType));
+        }
+
         public static string GetEffectText(MagicItemEffectDefinition effectDef, float value)
         {
             var localizedDisplayText = Localization.instance.Localize(effectDef.DisplayText);

--- a/EpicLoot/MagicItemEffectDefinition.cs
+++ b/EpicLoot/MagicItemEffectDefinition.cs
@@ -16,6 +16,7 @@ namespace EpicLoot
         public bool NoRoll;
         public bool ExclusiveSelf = true;
         public List<string> ExclusiveEffectTypes = new List<string>();
+        public List<string> RequiredEffectTypes = new List<string>();
         public List<ItemDrop.ItemData.ItemType> AllowedItemTypes = new List<ItemDrop.ItemData.ItemType>();
         public List<ItemDrop.ItemData.ItemType> ExcludedItemTypes = new List<ItemDrop.ItemData.ItemType>();
         public List<ItemRarity> AllowedRarities = new List<ItemRarity>();
@@ -63,6 +64,11 @@ namespace EpicLoot
             if (ExclusiveEffectTypes != null && ExclusiveEffectTypes.Count > 0)
             {
                 _sb.AppendLine($"> > **ExclusiveEffectTypes:** `{string.Join(", ", ExclusiveEffectTypes)}`");
+            }
+
+            if (RequiredEffectTypes != null && RequiredEffectTypes.Count > 0)
+            {
+                _sb.AppendLine($"> > **RequiredEffectTypes:** `{string.Join(", ", RequiredEffectTypes)}`");
             }
 
             if (AllowedItemTypes != null && AllowedItemTypes.Count > 0)
@@ -126,6 +132,11 @@ namespace EpicLoot
             }
 
             if (ExclusiveEffectTypes?.Count > 0 && magicItem.HasAnyEffect(ExclusiveEffectTypes))
+            {
+                return false;
+            }
+
+            if (RequiredEffectTypes?.Count > 0 && magicItem.HasAllEffect(RequiredEffectTypes))
             {
                 return false;
             }


### PR DESCRIPTION
 - Requires that certain effects exist before rolling other Effects
 - Can be combined with my other change (Id / Type disambiguation)
   to enable scenarios such as "only roll recalling on spears" as one
   effect definition and "only roll recalling if the non-spear weapon
   has already rolled throwable."
 - Could also be used for scenarios such as "Only roll LowHealth effects
   If the normal version already exists on a piece of equipment."
 - Could also be used for synergistic weighting "If you already Effect
    X, use a higher weighted roll of effect Y."