### PR TITLE
Checks for prefab.name as well.

### DIFF
--- a/EpicLoot/MagicItemEffectDefinition.cs
+++ b/EpicLoot/MagicItemEffectDefinition.cs
@@ -162,7 +162,10 @@ namespace EpicLoot
 
             if (AllowedItemNames?.Count > 0 && !AllowedItemNames.Contains(itemData.m_shared.m_name))
             {
-                return false;
+                if (!AllowedItemNames.Contains(itemData.m_dropPrefab.name))
+                {
+                    return false;
+                }
             }
 
             if (ExcludedItemNames?.Count > 0 && ExcludedItemNames.Contains(itemData.m_shared.m_name))


### PR DESCRIPTION
When checking the AllowedItemNames requirement for an enchant or legendary/set item, it also checks the item's prefab's name as well as just the itemdata's name.

This allows for more userfriendly input in the json files as this is the same name as the one used for the commands such as EpicLoot's own magicitem command or the default spawn command