### PR TITLE
Endless loading fix

### DIFF
--- a/ValheimUnity/Assets/EpicLoot/Prefabs/SFX/sfx_frostcone.prefab
+++ b/ValheimUnity/Assets/EpicLoot/Prefabs/SFX/sfx_frostcone.prefab
@@ -11,8 +11,6 @@ GameObject:
   - component: {fileID: 4590403118388710891}
   - component: {fileID: 7329369999073404582}
   - component: {fileID: 3284943680500979405}
-  - component: {fileID: -5052170193911513249}
-  - component: {fileID: 4759534943841606348}
   m_Layer: 0
   m_Name: sfx_frostcone
   m_TagString: Untagged
@@ -161,33 +159,3 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
---- !u!114 &-5052170193911513249
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1653710073109452256}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 469224316, guid: c1b78fa918b030faf1c1f6f6164daeb2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_timeout: 4
-  m_triggerOnAwake: 0
---- !u!114 &4759534943841606348
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1653710073109452256}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 1521249158, guid: c1b78fa918b030faf1c1f6f6164daeb2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_persistent: 0
-  m_distant: 0
-  m_type: 0
-  m_syncInitialScale: 0

--- a/ValheimUnity/Assets/EpicLoot/Prefabs/VFX/IceSpikes.prefab
+++ b/ValheimUnity/Assets/EpicLoot/Prefabs/VFX/IceSpikes.prefab
@@ -87561,8 +87561,7 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents:
-    - {fileID: -5052170193911513249, guid: 579f322edcce9bc499fc2bf60faf36b2, type: 3}
+    m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 579f322edcce9bc499fc2bf60faf36b2, type: 3}
 --- !u!4 &4887319297869530953 stripped
 Transform:


### PR DESCRIPTION
Fixed ice spikes effect causing endless loading. Sfx object was destroying but his ZDO was staying alive. Made sfx a part of effect prefab

Actual case was:
- Hit something with ragnar axe with 4 set items equipped
- To die

Result: loading will go forever

With respect from Ragnarök server team 👍 