### PR TITLE
Resolving a null error that can occur randomly on Dverger light.

### DIFF
--- a/DvergerColor/VisEquipment_Patch.cs
+++ b/DvergerColor/VisEquipment_Patch.cs
@@ -158,7 +158,11 @@ namespace DvergerColor
             }
 
             var light = __result.GetComponentInChildren<Light>();
-            __result.AddComponent<LightChanger>().SetLight(light);
+
+            if (light != null)
+            {
+                __result.AddComponent<LightChanger>().SetLight(light);
+            }
         }
     }
 }


### PR DESCRIPTION
In random cases, Dverger Circlet causes a null exception error.

Adding in a null check on light resolves the error.

```
[Error  : Unity Log] NullReferenceException: Object reference not set to an instance of an object
Stack trace:
DvergerColor.LightChanger.SetLight (UnityEngine.Light light) (at <6c1386359fb74ae08e08838392af46c2>:0)
DvergerColor.VisEquipment_AttachItem_Patch.Postfix (VisEquipment instance, UnityEngine.GameObject result, System.Int32 itemHash) (at <6c1386359fb74ae08e08838392af46c2>:0)
(wrapper dynamic-method) VisEquipment.DMD<VisEquipment::AttachItem>(VisEquipment,int,int,UnityEngine.Transform,bool,bool)
VisEquipment.SetHelmetEquiped (System.Int32 hash, System.Int32 hairHash) (at <035307060cbb4b30b916cd82ebd80490>:0)
VisEquipment.UpdateEquipmentVisuals () (at <035307060cbb4b30b916cd82ebd80490>:0)
VisEquipment.UpdateVisuals () (at <035307060cbb4b30b916cd82ebd80490>:0)
VisEquipment.Start () (at <035307060cbb4b30b916cd82ebd80490>:0)
```


(cherry picked from commit 3f1c7526a7a179430b5009a7fd76b7ac1a602b88)