### PR TITLE
Gated Boss Bounties

### DIFF
--- a/DvergerColor/VisEquipment_Patch.cs
+++ b/DvergerColor/VisEquipment_Patch.cs
@@ -158,7 +158,11 @@ namespace DvergerColor
             }
 
             var light = __result.GetComponentInChildren<Light>();
-            __result.AddComponent<LightChanger>().SetLight(light);
+
+            if (light != null)
+            {
+                __result.AddComponent<LightChanger>().SetLight(light);
+            }
         }
     }
 }

--- a/EpicLoot/Adventure/AdventureDataConfig.cs
+++ b/EpicLoot/Adventure/AdventureDataConfig.cs
@@ -105,6 +105,13 @@ namespace EpicLoot.Adventure
         public int RewardCoins;
         public List<BountyTargetAddConfig> Adds = new List<BountyTargetAddConfig>();
     }
+    
+    [Serializable]
+    public class BountyBossConfig
+    {
+        public Heightmap.Biome Biome;
+        public string BossName;
+    }
 
     [Serializable]
     public class BountiesConfig
@@ -120,9 +127,10 @@ namespace EpicLoot.Adventure
         public int AddsMaxLevel = 1;
         public float AddsHealthMultiplier = 1.0f;
         public List<BountyTargetConfig> Targets = new List<BountyTargetConfig>();
+        public List<BountyBossConfig> Bosses = new List<BountyBossConfig>();
         public BountyTargetNameConfig Names;
     }
-
+        
     [Serializable]
     public class AdventureDataConfig
     {

--- a/EpicLoot/EpicLoot.cs
+++ b/EpicLoot/EpicLoot.cs
@@ -39,6 +39,13 @@ namespace EpicLoot
         OnePerPlayerNearBoss
     }
 
+    public enum GatedBountyMode
+    {
+        Unlimited,
+        BossKillUnlocksCurrentBiomeBounties,
+        BossKillUnlocksNextBiomeBounties
+    }
+
     public class Assets
     {
         public AssetBundle AssetBundle;
@@ -102,6 +109,7 @@ namespace EpicLoot
         private static ConfigEntry<LogLevel> _logLevel;
         public static ConfigEntry<bool> UseGeneratedMagicItemNames;
         private static ConfigEntry<GatedItemTypeMode> _gatedItemTypeModeConfig;
+        public static ConfigEntry<GatedBountyMode> BossBountyMode;
         private static ConfigEntry<BossDropMode> _bossTrophyDropMode;
         private static ConfigEntry<float> _bossTrophyDropPlayerRange;
         private static ConfigEntry<int> _andvaranautRange;
@@ -189,6 +197,7 @@ namespace EpicLoot
             _logLevel = Config.Bind("Logging", "Log Level", LogLevel.Info, "Only log messages of the selected level or higher");
             UseGeneratedMagicItemNames = Config.Bind("General", "Use Generated Magic Item Names", true, "If true, magic items uses special, randomly generated names based on their rarity, type, and magic effects.");
             _gatedItemTypeModeConfig = SyncedConfig("Balance", "Item Drop Limits", GatedItemTypeMode.MustKnowRecipe, "Sets how the drop system limits what item types can drop. Unlimited: no limits, exactly what's in the loot table will drop. MustKnowRecipe: items will drop so long as the player has discovered their recipe. MustHaveCrafted: items will only drop once the player has crafted one or picked one up. If an item type cannot drop, it will downgrade to an item of the same type and skill that the player has unlocked (i.e. swords will stay swords)");
+            BossBountyMode = SyncedConfig("Balance", "Gated Bounty Mode", GatedBountyMode.Unlimited, "Sets whether available bounties are ungated or gated by boss kills.");
             _bossTrophyDropMode = SyncedConfig("Balance", "Boss Trophy Drop Mode", BossDropMode.OnePerPlayerNearBoss, "Sets bosses to drop a number of trophies equal to the number of players, similar to the way Wishbone works in vanilla. Optionally set it to only include players within a certain distance, use 'Boss Trophy Drop Player Range' to set the range.");
             _bossTrophyDropPlayerRange = SyncedConfig("Balance", "Boss Trophy Drop Player Range", 100.0f, "Sets the range that bosses check when dropping multiple trophies using the OnePerPlayerNearBoss drop mode.");
             _adventureModeEnabled = SyncedConfig("Balance", "Adventure Mode Enabled", true, "Set to true to enable all the adventure mode features: secret stash, gambling, treasure maps, and bounties. Set to false to disable. This will not actually remove active treasure maps or bounties from your save.");

--- a/EpicLoot/adventuredata.json
+++ b/EpicLoot/adventuredata.json
@@ -299,6 +299,14 @@
       { "Biome": "Mistlands",   "TargetID": "Seeker",           "RewardGold": 4, "RewardIron": 7, "RewardCoins": 1750,"Adds": [ { "ID": "SeekerBrood",  "Count": 10 } ] },
       { "Biome": "Mistlands",   "TargetID": "Gjall",            "RewardGold": 5, "RewardIron": 0, "RewardCoins": 1800 }
     ],
+    "Bosses": [
+		{"Biome": "Meadows", "BossName": "eikthyr"},
+		{"Biome": "BlackForest", "BossName": "gdking"},
+		{"Biome": "Swamp", "BossName": "bonemass"},
+		{"Biome": "Mountain", "BossName": "dragon"},
+		{"Biome": "Plains", "BossName": "goblinking"},
+		{"Biome": "Mistlands", "BossName": "queen"}
+    ],
     "Names": {
       "ChanceForSpecialName": 0.01,
       "SpecialNames": [


### PR DESCRIPTION
Enabling Configuration functionality to make the Boss Bounties Gated based on Bosses killed on the server.

The default configuration is Ungated.

Can be set to show Bounties based on the Current Biome with Boss killed, or show bounties for the Next Biome. allowing bounties from the next biome to show prior to killing that biome's boss.