### PR TITLE
Ensuring Ocean Boss is till reflective if Player visited biome

### DIFF
--- a/EpicLoot/Adventure/Feature/Bounties.cs
+++ b/EpicLoot/Adventure/Feature/Bounties.cs
@@ -63,7 +63,7 @@ namespace EpicLoot.Adventure.Feature
                     {
                         defeatedBossBiomes.Add(bossConfig.Biome);
                         previousBossKilled = false;
-                    }
+                    } 
                 }
             }
 
@@ -84,7 +84,7 @@ namespace EpicLoot.Adventure.Feature
             if (BossBountiesGated()) 
             {
                 //Remove the results of undefeated biome bosses
-                selectedTargets.RemoveAll(result => !defeatedBossBiomes.Contains(result.Biome));
+                selectedTargets.RemoveAll(result => !defeatedBossBiomes.Contains(result.Biome) && result.Biome.ToString() != "Ocean");
             }
 
             var saveData = player.GetAdventureSaveData();


### PR DESCRIPTION
There's no Ocean Boss to kill, and thus the logic was preventing the Ocean Bounty from showing up.

Fixed it to where Ocean bounty will show if Gated Bosses is turned on, and player has visited the Ocean biome.