### PR TITLE
Ensuring that if Ungate Next Boss is set, that first bounties are set.

### DIFF
--- a/EpicLoot/Adventure/Feature/Bounties.cs
+++ b/EpicLoot/Adventure/Feature/Bounties.cs
@@ -48,19 +48,28 @@ namespace EpicLoot.Adventure.Feature
             
             var defeatedBossBiomes = new List<Heightmap.Biome>();
             var previousBossKilled = false;
+            var previousBoss = "";
 
             if (BossBountiesGated())
             {
                 foreach (var bossConfig in Bosses.BossData)
                 {
+                    if (previousBoss == "" && EpicLoot.BossBountyMode.Value == GatedBountyMode.BossKillUnlocksNextBiomeBounties)
+                    {
+                        defeatedBossBiomes.Add(bossConfig.Biome);
+                        previousBoss = bossConfig.BossDefeatedKey;
+                    }
+
                     if (ZoneSystem.instance.GetGlobalKey(bossConfig.BossDefeatedKey))
                     {
                         defeatedBossBiomes.Add(bossConfig.Biome);
                         previousBossKilled = true;
+                        previousBoss = bossConfig.BossDefeatedKey;
                     }
-                    else if (previousBossKilled && EpicLoot.BossBountyMode.Value == GatedBountyMode.BossKillUnlocksNextBiomeBounties)
+                    else if ((previousBossKilled || previousBoss.Equals(bossConfig.BossDefeatedKey)) && EpicLoot.BossBountyMode.Value == GatedBountyMode.BossKillUnlocksNextBiomeBounties)
                     {
                         defeatedBossBiomes.Add(bossConfig.Biome);
+                        previousBoss = bossConfig.BossDefeatedKey;
                         previousBossKilled = false;
                     }
                 }


### PR DESCRIPTION
Ensuring that Meadow's bounties (or whatever is the first biome) are available when NextBoss is set in config.
(cherry picked from commit ec3e529f9e6096da245c6106d346ba8c48b194d7)