### PR TITLE
CLLC Compatibility Fix

### DIFF
--- a/EpicLoot/CharacterDrop_Patch.cs
+++ b/EpicLoot/CharacterDrop_Patch.cs
@@ -10,21 +10,15 @@ namespace EpicLoot
     [HarmonyPatch(typeof(CharacterDrop), nameof(CharacterDrop.OnDeath))]
     public static class CharacterDrop_OnDeath_Patch
     {
-        private static bool _originalDropsEnabled = false;
-
-        public static void Prefix(CharacterDrop __instance)
-        {
-            _originalDropsEnabled = __instance.m_dropsEnabled;
-        }
-
         public static void Postfix(CharacterDrop __instance)
         {
-            if (_originalDropsEnabled)
+            if (EpicLoot.DropsEnabled)
             {
                 EpicLoot.OnCharacterDeath(__instance);
             }
         }
     }
+
 
     [HarmonyPatch(typeof(Ragdoll), nameof(Ragdoll.Setup))]
     public static class Ragdoll_Setup_Patch
@@ -43,7 +37,6 @@ namespace EpicLoot
 
             var characterName = EpicLoot.GetCharacterCleanName(characterDrop.m_character);
             var level = characterDrop.m_character.GetLevel();
-
             __instance.m_nview.m_zdo.Set("characterName", characterName);
             __instance.m_nview.m_zdo.Set("level", level);
         }
@@ -56,10 +49,21 @@ namespace EpicLoot
         {
             var characterName = __instance.m_nview.m_zdo.GetString("characterName");
             var level = __instance.m_nview.m_zdo.GetInt("level");
+
             if (!string.IsNullOrEmpty(characterName))
             {
                 EpicLoot.OnCharacterDeath(characterName, level, center + Vector3.up * 0.75f);
             }
+        }
+    }
+    [HarmonyPatch(typeof(CharacterDrop), nameof(CharacterDrop.GenerateDropList))]
+    public static class CharacterDrop_GenerateDropList_DropsEnabled
+    {
+        [HarmonyPriority(Priority.First)]
+        [HarmonyBefore(new string[] { "org.bepinex.plugins.creaturelevelcontrol" })]
+        public static void Postfix(CharacterDrop __instance, ref List<KeyValuePair<GameObject, int>> __result)
+        {
+            EpicLoot.DropsEnabled = __instance.m_dropsEnabled ? true : false;
         }
     }
 

--- a/EpicLoot/CharacterDrop_Patch.cs
+++ b/EpicLoot/CharacterDrop_Patch.cs
@@ -10,9 +10,16 @@ namespace EpicLoot
     [HarmonyPatch(typeof(CharacterDrop), nameof(CharacterDrop.OnDeath))]
     public static class CharacterDrop_OnDeath_Patch
     {
+        private static bool _originalDropsEnabled = false;
+
+        public static void Prefix(CharacterDrop __instance)
+        {
+            _originalDropsEnabled = __instance.m_dropsEnabled;
+        }
+
         public static void Postfix(CharacterDrop __instance)
         {
-            if (__instance.m_dropsEnabled)
+            if (_originalDropsEnabled)
             {
                 EpicLoot.OnCharacterDeath(__instance);
             }

--- a/EpicLoot/EpicLoot.cs
+++ b/EpicLoot/EpicLoot.cs
@@ -167,6 +167,8 @@ namespace EpicLoot
         public const Minimap.PinType TreasureMapPinType = (Minimap.PinType) 801;
         public static bool HasAuga;
         public static bool AugaTooltipNoTextBoxes;
+        private static bool _dropsEnabled = false;
+        
 
         public static event Action AbilitiesInitialized;
         public static event Action LootTableLoaded;
@@ -174,6 +176,8 @@ namespace EpicLoot
         private static EpicLoot _instance;
         private Harmony _harmony;
         private float _worldLuckFactor;
+
+        public static bool DropsEnabled { get => _dropsEnabled; set => _dropsEnabled = value; }
 
         [UsedImplicitly]
         private void Awake()


### PR DESCRIPTION
This change allows EpicLoot and CLLC to co-exist in peaceful Harmony.   Mistlands Creatures, Skeletons, Moder, and Bonemass now drop EpicLoot as expected.

The change involved ensuring that EpicLoot captures the __instance.m_dropEnabled setting prior to other mods, including CLLC from being able to modify it before execution.  Then saves it as a local variable for consumption in other places.

The issue surrounds the fact that Mistlands creatures and bosses do not have Ragdolls on death.