### PR TITLE
Adding in feedback to the user that adventure.json has not been updated.

### DIFF
--- a/EpicLoot/Adventure/Feature/Bosses.cs
+++ b/EpicLoot/Adventure/Feature/Bosses.cs
@@ -6,9 +6,17 @@ namespace EpicLoot.Adventure.Feature
     {
         public static string GetPrevBossKey(string bossKey)
         {
+            if (AdventureDataManager.Config.Bounties.Bosses == null || AdventureDataManager.Config.Bounties.Bosses.Count == 0)
+            {
+                throw new System.Exception(($"[Adventure Bounty Error]: adventure.json has not been updated or is missing boss config.  Please update JSON files."));
+
+            }
+
             var index = AdventureDataManager.Config.Bounties.Bosses.FindIndex(x => x.BossDefeatedKey == bossKey);
+
             if (index == 0 || index >= AdventureDataManager.Config.Bounties.Bosses.Count)
                 return null;
+
             return AdventureDataManager.Config.Bounties.Bosses[index - 1].BossDefeatedKey;
         }
     }


### PR DESCRIPTION
Custom error message to alert the user that the json file hasn't been updated or is missing a boss config.
(cherry picked from commit 634cbc1d67faee2cf5e42eaecca364c3b8da86e0)