### PR TITLE
Localized Item Asset Names

### DIFF
--- a/EpicLoot/EpicLoot.cs
+++ b/EpicLoot/EpicLoot.cs
@@ -100,10 +100,6 @@ namespace EpicLoot
         private static ConfigEntry<int> _rareMaterialIconColor;
         private static ConfigEntry<int> _epicMaterialIconColor;
         private static ConfigEntry<int> _legendaryMaterialIconColor;
-        private static ConfigEntry<string> _magicRarityDisplayName;
-        private static ConfigEntry<string> _rareRarityDisplayName;
-        private static ConfigEntry<string> _epicRarityDisplayName;
-        private static ConfigEntry<string> _legendaryRarityDisplayName;
         public static ConfigEntry<bool> UseScrollingCraftDescription;
         public static ConfigEntry<CraftingTabStyle> CraftingTabStyle;
         private static ConfigEntry<bool> _loggingEnabled;
@@ -192,10 +188,6 @@ namespace EpicLoot
             _legendaryRarityColor = Config.Bind("Item Colors", "Legendary Rarity Color", "Teal", "The color of Legendary rarity items, the highest magic item tier. (Optional, use an HTML hex color starting with # to have a custom color.) Available options: Red, Orange, Yellow, Green, Teal, Blue, Indigo, Purple, Pink, Gray");
             _legendaryMaterialIconColor = Config.Bind("Item Colors", "Legendary Crafting Material Icon Index", 4, "Indicates the color of the icon used for legendary crafting materials. A number between 0 and 9. Available options: 0=Red, 1=Orange, 2=Yellow, 3=Green, 4=Teal, 5=Blue, 6=Indigo, 7=Purple, 8=Pink, 9=Gray");
             _setItemColor = Config.Bind("Item Colors", "Set Item Color", "#26ffff", "The color of set item text and the set item icon. Use a hex color, default is cyan");
-            _magicRarityDisplayName = Config.Bind("Rarity", "Magic Rarity Display Name", "$mod_epicloot_magic", "The name of the lowest rarity.");
-            _rareRarityDisplayName = Config.Bind("Rarity", "Rare Rarity Display Name", "$mod_epicloot_rare", "The name of the second rarity.");
-            _epicRarityDisplayName = Config.Bind("Rarity", "Epic Rarity Display Name", "$mod_epicloot_epic", "The name of the third rarity.");
-            _legendaryRarityDisplayName = Config.Bind("Rarity", "Legendary Rarity Display Name", "$mod_epicloot_legendary", "The name of the highest rarity.");
             UseScrollingCraftDescription = Config.Bind("Crafting UI", "Use Scrolling Craft Description", true, "Changes the item description in the crafting panel to scroll instead of scale when it gets too long for the space.");
             CraftingTabStyle = Config.Bind("Crafting UI", "Crafting Tab Style", Crafting.CraftingTabStyle.HorizontalSquish, "Sets the layout style for crafting tabs, if you've got too many. Horizontal is the vanilla method, but might overlap other mods or run off the screen. HorizontalSquish makes the buttons narrower, works okay with 6 or 7 buttons. Vertical puts the tabs in a column to the left the crafting window. Angled tries to make more room at the top of the crafting panel by angling the tabs, works okay with 6 or 7 tabs.");
             ShowEquippedAndHotbarItemsInSacrificeTab = Config.Bind("Crafting UI", "ShowEquippedAndHotbarItemsInSacrificeTab", false, "If set to false, hides the items that are equipped or on your hotbar in the Sacrifice items list.");
@@ -737,21 +729,18 @@ namespace EpicLoot
                 return;
             }
 
-            // Fix custom name and icons for crafting materials
+            
             foreach (var prefab in RegisteredItemPrefabs)
             {
                 var itemDrop = prefab.GetComponent<ItemDrop>();
                 if (itemDrop != null)
                 {
+                    //Set icons for crafting materials
+
                     if (itemDrop.m_itemData.IsMagicCraftingMaterial() || itemDrop.m_itemData.IsRunestone())
                     {
                         var rarity = itemDrop.m_itemData.GetRarity();
-                        var correctName = GetRarityDisplayName(rarity);
-                        if (!itemDrop.m_itemData.m_shared.m_name.StartsWith(correctName))
-                        {
-                            itemDrop.m_itemData.m_shared.m_name = itemDrop.m_itemData.m_shared.m_name.Replace(rarity.ToString(), correctName);
-                        }
-
+                        
                         if (itemDrop.m_itemData.IsMagicCraftingMaterial())
                         {
                             itemDrop.m_itemData.m_variant = GetRarityIconIndex(rarity);
@@ -1368,13 +1357,13 @@ namespace EpicLoot
             switch (rarity)
             {
                 case ItemRarity.Magic:
-                    return _magicRarityDisplayName.Value;
+                    return "$mod_epicloot_magic";
                 case ItemRarity.Rare:
-                    return _rareRarityDisplayName.Value;
+                    return "$mod_epicloot_rare";
                 case ItemRarity.Epic:
-                    return _epicRarityDisplayName.Value;
+                    return "$mod_epicloot_epic";
                 case ItemRarity.Legendary:
-                    return _legendaryRarityDisplayName.Value;
+                    return "$mod_epicloot_legendary";
                 default:
                     throw new ArgumentOutOfRangeException(nameof(rarity), rarity, null);
             }

--- a/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/DustEpic.prefab
+++ b/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/DustEpic.prefab
@@ -144,7 +144,7 @@ PrefabInstance:
     - target: {fileID: 8495594747941318552, guid: c8d9be30add4b914cbe91a4732a05c05,
         type: 3}
       propertyPath: m_itemData.m_shared.m_name
-      value: Epic $mod_epicloot_assets_dust
+      value: $mod_epicloot_epic $mod_epicloot_assets_dust
       objectReference: {fileID: 0}
     - target: {fileID: 8495594747941318552, guid: c8d9be30add4b914cbe91a4732a05c05,
         type: 3}

--- a/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/DustLegendary.prefab
+++ b/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/DustLegendary.prefab
@@ -10,7 +10,7 @@ PrefabInstance:
     - target: {fileID: 198913167976628282, guid: 2240de27b5e08e845b1b823b1e94dfa8,
         type: 3}
       propertyPath: m_itemData.m_shared.m_name
-      value: Legendary $mod_epicloot_assets_dust
+      value: $mod_epicloot_legendary $mod_epicloot_assets_dust
       objectReference: {fileID: 0}
     - target: {fileID: 198913167976628282, guid: 2240de27b5e08e845b1b823b1e94dfa8,
         type: 3}

--- a/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/DustMagic.prefab
+++ b/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/DustMagic.prefab
@@ -15,7 +15,7 @@ PrefabInstance:
     - target: {fileID: 124223530235104039, guid: f8c9237298dab3a438c66dbedd157d72,
         type: 3}
       propertyPath: m_itemData.m_shared.m_name
-      value: Magic $mod_epicloot_assets_dust
+      value: $mod_epicloot_magic $mod_epicloot_assets_dust
       objectReference: {fileID: 0}
     - target: {fileID: 124223530235104039, guid: f8c9237298dab3a438c66dbedd157d72,
         type: 3}

--- a/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/DustRare.prefab
+++ b/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/DustRare.prefab
@@ -54,7 +54,7 @@ PrefabInstance:
     - target: {fileID: 4812765547126240509, guid: 6576477ba955d1d498e87413b5318733,
         type: 3}
       propertyPath: m_itemData.m_shared.m_name
-      value: Rare $mod_epicloot_assets_dust
+      value: $mod_epicloot_rare $mod_epicloot_assets_dust
       objectReference: {fileID: 0}
     - target: {fileID: 4812765547126240509, guid: 6576477ba955d1d498e87413b5318733,
         type: 3}

--- a/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/EssenceEpic.prefab
+++ b/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/EssenceEpic.prefab
@@ -75,7 +75,7 @@ PrefabInstance:
     - target: {fileID: 8495594747941318552, guid: c8d9be30add4b914cbe91a4732a05c05,
         type: 3}
       propertyPath: m_itemData.m_shared.m_name
-      value: Epic $mod_epicloot_assets_essence
+      value: $mod_epicloot_epic $mod_epicloot_assets_essence
       objectReference: {fileID: 0}
     - target: {fileID: 8495594747941318552, guid: c8d9be30add4b914cbe91a4732a05c05,
         type: 3}

--- a/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/EssenceLegendary.prefab
+++ b/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/EssenceLegendary.prefab
@@ -10,7 +10,7 @@ PrefabInstance:
     - target: {fileID: 198913167976628282, guid: 2240de27b5e08e845b1b823b1e94dfa8,
         type: 3}
       propertyPath: m_itemData.m_shared.m_name
-      value: Legendary $mod_epicloot_assets_essence
+      value: $mod_epicloot_legendary $mod_epicloot_assets_essence
       objectReference: {fileID: 0}
     - target: {fileID: 198913167976628282, guid: 2240de27b5e08e845b1b823b1e94dfa8,
         type: 3}

--- a/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/EssenceMagic.prefab
+++ b/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/EssenceMagic.prefab
@@ -59,7 +59,7 @@ PrefabInstance:
     - target: {fileID: 124223530235104039, guid: f8c9237298dab3a438c66dbedd157d72,
         type: 3}
       propertyPath: m_itemData.m_shared.m_name
-      value: Magic $mod_epicloot_assets_essence
+      value: $mod_epicloot_magic $mod_epicloot_assets_essence
       objectReference: {fileID: 0}
     - target: {fileID: 124223530235104039, guid: f8c9237298dab3a438c66dbedd157d72,
         type: 3}

--- a/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/EssenceRare.prefab
+++ b/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/EssenceRare.prefab
@@ -54,7 +54,7 @@ PrefabInstance:
     - target: {fileID: 4812765547126240509, guid: 6576477ba955d1d498e87413b5318733,
         type: 3}
       propertyPath: m_itemData.m_shared.m_name
-      value: Rare $mod_epicloot_assets_essence
+      value: $mod_epicloot_rare $mod_epicloot_assets_essence
       objectReference: {fileID: 0}
     - target: {fileID: 4812765547126240509, guid: 6576477ba955d1d498e87413b5318733,
         type: 3}

--- a/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/ReagentEpic.prefab
+++ b/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/ReagentEpic.prefab
@@ -124,7 +124,7 @@ PrefabInstance:
     - target: {fileID: 8495594747941318552, guid: c8d9be30add4b914cbe91a4732a05c05,
         type: 3}
       propertyPath: m_itemData.m_shared.m_name
-      value: Epic $mod_epicloot_assets_reagent
+      value: $mod_epicloot_epic $mod_epicloot_assets_reagent
       objectReference: {fileID: 0}
     - target: {fileID: 8495594747941318552, guid: c8d9be30add4b914cbe91a4732a05c05,
         type: 3}

--- a/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/ReagentLegendary.prefab
+++ b/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/ReagentLegendary.prefab
@@ -10,7 +10,7 @@ PrefabInstance:
     - target: {fileID: 198913167976628282, guid: 2240de27b5e08e845b1b823b1e94dfa8,
         type: 3}
       propertyPath: m_itemData.m_shared.m_name
-      value: Legendary $mod_epicloot_assets_reagent
+      value: $mod_epicloot_legendary $mod_epicloot_assets_reagent
       objectReference: {fileID: 0}
     - target: {fileID: 198913167976628282, guid: 2240de27b5e08e845b1b823b1e94dfa8,
         type: 3}

--- a/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/ReagentMagic.prefab
+++ b/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/ReagentMagic.prefab
@@ -59,7 +59,7 @@ PrefabInstance:
     - target: {fileID: 124223530235104039, guid: f8c9237298dab3a438c66dbedd157d72,
         type: 3}
       propertyPath: m_itemData.m_shared.m_name
-      value: Magic $mod_epicloot_assets_reagent
+      value: $mod_epicloot_magic $mod_epicloot_assets_reagent
       objectReference: {fileID: 0}
     - target: {fileID: 124223530235104039, guid: f8c9237298dab3a438c66dbedd157d72,
         type: 3}

--- a/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/RunestoneEpic.prefab
+++ b/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/RunestoneEpic.prefab
@@ -170,7 +170,7 @@ PrefabInstance:
     - target: {fileID: 8495594747941318552, guid: c8d9be30add4b914cbe91a4732a05c05,
         type: 3}
       propertyPath: m_itemData.m_shared.m_name
-      value: Epic $mod_epicloot_assets_runestone
+      value: $mod_epicloot_epic $mod_epicloot_assets_runestone
       objectReference: {fileID: 0}
     - target: {fileID: 8495594747941318552, guid: c8d9be30add4b914cbe91a4732a05c05,
         type: 3}

--- a/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/RunestoneLegendary.prefab
+++ b/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/RunestoneLegendary.prefab
@@ -15,7 +15,7 @@ PrefabInstance:
     - target: {fileID: 198913167976628282, guid: 2240de27b5e08e845b1b823b1e94dfa8,
         type: 3}
       propertyPath: m_itemData.m_shared.m_name
-      value: Legendary $mod_epicloot_assets_runestone
+      value: $mod_epicloot_legendary $mod_epicloot_assets_runestone
       objectReference: {fileID: 0}
     - target: {fileID: 198913167976628282, guid: 2240de27b5e08e845b1b823b1e94dfa8,
         type: 3}

--- a/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/RunestoneMagic.prefab
+++ b/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/RunestoneMagic.prefab
@@ -69,7 +69,7 @@ PrefabInstance:
     - target: {fileID: 124223530235104039, guid: f8c9237298dab3a438c66dbedd157d72,
         type: 3}
       propertyPath: m_itemData.m_shared.m_name
-      value: Magic $mod_epicloot_assets_runestone
+      value: $mod_epicloot_magic $mod_epicloot_assets_runestone
       objectReference: {fileID: 0}
     - target: {fileID: 124223530235104039, guid: f8c9237298dab3a438c66dbedd157d72,
         type: 3}

--- a/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/RunestoneRare.prefab
+++ b/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/RunestoneRare.prefab
@@ -31,7 +31,7 @@ PrefabInstance:
     - target: {fileID: 4812765547126240509, guid: 6576477ba955d1d498e87413b5318733,
         type: 3}
       propertyPath: m_itemData.m_shared.m_name
-      value: Rare $mod_epicloot_assets_runestone
+      value: $mod_epicloot_rare $mod_epicloot_assets_runestone
       objectReference: {fileID: 0}
     - target: {fileID: 4812765547126240509, guid: 6576477ba955d1d498e87413b5318733,
         type: 3}

--- a/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/ShardEpic.prefab
+++ b/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/ShardEpic.prefab
@@ -81,7 +81,7 @@ PrefabInstance:
     - target: {fileID: 8495594747941318552, guid: c8d9be30add4b914cbe91a4732a05c05,
         type: 3}
       propertyPath: m_itemData.m_shared.m_name
-      value: Epic $mod_epicloot_assets_shard
+      value: $mod_epicloot_epic $mod_epicloot_assets_shard
       objectReference: {fileID: 0}
     - target: {fileID: 8495594747941318552, guid: c8d9be30add4b914cbe91a4732a05c05,
         type: 3}

--- a/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/ShardLegendary.prefab
+++ b/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/ShardLegendary.prefab
@@ -10,7 +10,7 @@ PrefabInstance:
     - target: {fileID: 198913167976628282, guid: 2240de27b5e08e845b1b823b1e94dfa8,
         type: 3}
       propertyPath: m_itemData.m_shared.m_name
-      value: Legendary $mod_epicloot_assets_shard
+      value: $mod_epicloot_legendary $mod_epicloot_assets_shard
       objectReference: {fileID: 0}
     - target: {fileID: 198913167976628282, guid: 2240de27b5e08e845b1b823b1e94dfa8,
         type: 3}

--- a/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/ShardMagic.prefab
+++ b/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/ShardMagic.prefab
@@ -84,7 +84,7 @@ PrefabInstance:
     - target: {fileID: 124223530235104039, guid: f8c9237298dab3a438c66dbedd157d72,
         type: 3}
       propertyPath: m_itemData.m_shared.m_name
-      value: Magic $mod_epicloot_assets_shard
+      value: $mod_epicloot_magic $mod_epicloot_assets_shard
       objectReference: {fileID: 0}
     - target: {fileID: 124223530235104039, guid: f8c9237298dab3a438c66dbedd157d72,
         type: 3}

--- a/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/ShardRare.prefab
+++ b/ValheimUnity/Assets/EpicLoot/Prefabs/CraftingMaterials/ShardRare.prefab
@@ -16,7 +16,7 @@ PrefabInstance:
     - target: {fileID: 4812765547126240509, guid: 6576477ba955d1d498e87413b5318733,
         type: 3}
       propertyPath: m_itemData.m_shared.m_name
-      value: Rare $mod_epicloot_assets_shard
+      value: $mod_epicloot_rare $mod_epicloot_assets_shard
       objectReference: {fileID: 0}
     - target: {fileID: 4812765547126240509, guid: 6576477ba955d1d498e87413b5318733,
         type: 3}


### PR DESCRIPTION
Removes the logic for deriving the Rarity name from a Config value and standardizes on using the Localized string.  Also includes Unity changes that update the names of the items.

(cherry picked from commit eedda08121ecf894684153f10912d0a850954b83)