### PR TITLE
Removing Timescale.

### DIFF
--- a/EpicLoot/Terminal_Patch.cs
+++ b/EpicLoot/Terminal_Patch.cs
@@ -142,16 +142,6 @@ namespace EpicLoot
                 var availableBounties = player.GetAdventureSaveData().Bounties;
                 BountiesAdventureFeature.PrintBounties($"Player Bounties:", availableBounties);
             }));
-            new Terminal.ConsoleCommand("timescale", "", (args =>
-            {
-                var timeScale = (args.Length >= 2) ? float.Parse(args[1]) : 1;
-                Time.timeScale = timeScale;
-            }), true);
-            new Terminal.ConsoleCommand("ts", "", (args =>
-            {
-                var timeScale = (args.Length >= 2) ? float.Parse(args[1]) : 1;
-                Time.timeScale = timeScale;
-            }), true);
             new Terminal.ConsoleCommand("gotomerchant", "", (args =>
             {
                 var player = Player.m_localPlayer;


### PR DESCRIPTION
The terminal command Timescale was not working, and was covering up the vanilla command doing the same thing.

Removing it.

(cherry picked from commit 8f78d5ec9415e1ca7c9f638184530840f0e1771d)