### PR TITLE
Fixing the Background Issue on HotKeyBar.

### DIFF
--- a/EpicLoot/MagicItemComponent.cs
+++ b/EpicLoot/MagicItemComponent.cs
@@ -691,19 +691,20 @@ namespace EpicLoot
     {
         public static void Postfix(HotkeyBar __instance, List<HotkeyBar.ElementData> ___m_elements, List<ItemDrop.ItemData> ___m_items, Player player)
         {
-            if (player == null || player.IsDead())
+
+            if (!__instance.name.Equals("HotKeyBar") || player == null || player.IsDead()) return;
+
+            for (var index = 0; index < Player.m_localPlayer.GetInventory().m_width; index++)
             {
-                return;
-            }
+                var itemData = __instance.m_items.FirstOrDefault(x => x.m_gridPos.x.Equals(index));
 
-            foreach (var itemData in __instance.m_items)
-            {
-                if (itemData.m_gridPos.x < 0 || itemData.m_gridPos.x >= __instance.m_elements.Count) continue;
+                if (index < 0 || index >= __instance.m_elements.Count) continue;
 
-                var element = __instance.m_elements[itemData.m_gridPos.x];
+                var element = __instance.m_elements[index];
 
-                var magicItem = ItemBackgroundHelper.CreateAndGetMagicItemBackgroundImage(element.m_go, element.m_equiped, false);
-                if (itemData.UseMagicBackground())
+                var magicItem =
+                    ItemBackgroundHelper.CreateAndGetMagicItemBackgroundImage(element.m_go, element.m_equiped, false);
+                if (itemData != null && itemData.UseMagicBackground())
                 {
                     magicItem.enabled = true;
                     magicItem.sprite = EpicLoot.GetMagicItemBgSprite();


### PR DESCRIPTION
Refactored Logic didn't take into consideration the difference between element count and item count.

This now circulates through the width of the Player's inventory and then matches based on the grid position, if an item isn't found, it disables the background.

Also restricting it so that Equipment Slots (and other mods) don't activate this logic.

(cherry picked from commit e3d940b857ca7ef2b1f17eb8a7ad213c54829ca7)