### PR TITLE
Extended Auga Tooltip fails when there's not a localized variable in …

### DIFF
--- a/EpicLoot/EpicLoot.cs
+++ b/EpicLoot/EpicLoot.cs
@@ -315,14 +315,25 @@ namespace EpicLoot
 
                 Auga.API.ComplexTooltip_SetIcon(complexTooltip, item.GetIcon());
 
+                string localizedSubtitle;
                 if (item.IsLegendarySetItem())
                 {
-                    Auga.API.ComplexTooltip_SetSubtitle(complexTooltip, Localization.instance.Localize($"<color={GetSetItemColor()}>$mod_epicloot_legendarysetlabel</color>, {itemTypeName}\n"));
+                    localizedSubtitle = $"<color={GetSetItemColor()}>$mod_epicloot_legendarysetlabel</color>, {itemTypeName}\n";
                 }
                 else
                 {
-                    Auga.API.ComplexTooltip_SetSubtitle(complexTooltip, Localization.instance.Localize($"<color={magicColor}>{magicItem.GetRarityDisplay()} {itemTypeName}</color>"));
+                    localizedSubtitle = $"<color={magicColor}>{magicItem.GetRarityDisplay()} {itemTypeName}</color>";
                 }
+
+                try
+                {
+                    Auga.API.ComplexTooltip_SetSubtitle(complexTooltip, Localization.instance.Localize(localizedSubtitle));
+                }
+                catch (Exception)
+                {
+                    Auga.API.ComplexTooltip_SetSubtitle(complexTooltip, localizedSubtitle);
+                }
+
 
                 if (AugaTooltipNoTextBoxes)
                     return;
@@ -340,7 +351,15 @@ namespace EpicLoot
                     Auga.API.TooltipTextBox_AddLine(textBox2, item.GetSetTooltip());
                 }
 
-                Auga.API.ComplexTooltip_SetDescription(complexTooltip, Localization.instance.Localize(item.GetDescription()));
+                try
+                {
+                    Auga.API.ComplexTooltip_SetDescription(complexTooltip, Localization.instance.Localize(item.GetDescription()));
+                }
+                catch (Exception)
+                {
+                    Auga.API.ComplexTooltip_SetDescription(complexTooltip, item.GetDescription());
+                }
+                
             }
         }
 


### PR DESCRIPTION
…translations.json.  This has come up with the introduction of Config Patching and people making new item name's without a translation.

This makes Auga fail gracefully.

Fixes #469 

(cherry picked from commit 41c5081c53576129301515046624537fc80ac21f)