### PR TITLE
Adding On-the-fly patching capability with Translation.json

### DIFF
--- a/EpicLoot/Data/ConfigValue.cs
+++ b/EpicLoot/Data/ConfigValue.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using JetBrains.Annotations;
+
+namespace EpicLoot.Data
+{
+    public enum ConfigType
+    {
+        Synced,
+        Nonsynced
+    }
+
+    public abstract class ConfigValueBase
+    {
+        public readonly string Identifier;
+        public readonly Type Type;
+        private object? _boxedValue;
+
+        [CanBeNull] public event Action ValueChanged;
+
+        public object? BoxedValue
+        {
+            get => _boxedValue;
+            set
+            {
+                _boxedValue = value;
+                var valueChanged = ValueChanged;
+                if (valueChanged == null)
+                    return;
+                valueChanged();
+            }
+        }
+        protected ConfigValueBase(string identifier, Type type)
+        {
+            Identifier = identifier;
+            Type = type;
+        }
+    }
+
+    public sealed class ConfigValue<T> : ConfigValueBase
+    {
+        public T Value
+        {
+            get => (T)BoxedValue;
+            set => BoxedValue = value;
+        }
+
+        public ConfigValue(string identifier, T value = default)
+            : base(identifier, typeof(T))
+        {
+            Value = value;
+        }
+
+        public void AssignValue(T value)
+        {
+            Value = value;
+        }
+    }
+
+}

--- a/EpicLoot/EpicLoot.cs
+++ b/EpicLoot/EpicLoot.cs
@@ -383,9 +383,7 @@ namespace EpicLoot
             //Load New Translations
             foreach (var translation in translations)
             {
-                var keyName = translation.Key.StartsWith(translationPrefix) ? translation.Key : $"{translationPrefix}{translation.Key}";
-
-                Localization.instance.AddWord(keyName, translation.Value.ToString());
+                Localization.instance.AddWord(translation.Key, translation.Value.ToString());
             }
         }
 

--- a/EpicLoot/EpicLoot.csproj
+++ b/EpicLoot/EpicLoot.csproj
@@ -22,6 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -30,6 +31,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
@@ -111,6 +113,7 @@
     <Compile Include="Abilities\PlayerExtensions_Abilities.cs" />
     <Compile Include="Adventure\Feature\Bosses.cs" />
     <Compile Include="Adventure\Feature\BountyLedger.cs" />
+    <Compile Include="Data\ConfigValue.cs" />
     <Compile Include="DebugText.cs" />
     <Compile Include="GameCamera_Patch.cs" />
     <Compile Include="Healing\AddHealingQueueToPlayerPatch.cs" />


### PR DESCRIPTION
Enables the Patching of Translation.json using the new Patching System.  Also ensures that translations added to the Localization dictionary are specific to EpicLoot by ensuring that mod translation name begins with "mod_epicloot_".

Fixes #468 

(cherry picked from commit 2e7ef98918eb575a9f1d526fbae11c56669c87a7)