### PR TITLE
Available Effects Clipping 

### DIFF
--- a/EpicLoot/Crafting/AugmentTabController.cs
+++ b/EpicLoot/Crafting/AugmentTabController.cs
@@ -117,10 +117,13 @@ namespace EpicLoot.Crafting
                     AvailableAugmentsDialog.MagicBG.color = Color.white;
 
                     AvailableAugmentsDialog.NameText = Object.Instantiate(inventoryGui.m_recipeName, background);
+
                     AvailableAugmentsDialog.Description = Object.Instantiate(inventoryGui.m_recipeDecription, background);
-                    AvailableAugmentsDialog.Description.rectTransform.anchoredPosition += new Vector2(0, -110);
-                    AvailableAugmentsDialog.Description.rectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, 460);
-                    AvailableAugmentsDialog.Description.resizeTextForBestFit = true;
+                    AvailableAugmentsDialog.Description.verticalOverflow = VerticalWrapMode.Overflow;
+                    AvailableAugmentsDialog.Description.horizontalOverflow = HorizontalWrapMode.Overflow;
+                    AvailableAugmentsDialog.Description.rectTransform.anchoredPosition += new Vector2(0, -100);
+                    AvailableAugmentsDialog.Description.rectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, 480);
+
                     AvailableAugmentsDialog.Icon = Object.Instantiate(inventoryGui.m_recipeIcon, background);
 
                     var closeButton = AvailableAugmentsDialog.gameObject.GetComponentInChildren<Button>();

--- a/EpicLoot/Crafting/AugmentsAvailableDialog.cs
+++ b/EpicLoot/Crafting/AugmentsAvailableDialog.cs
@@ -59,13 +59,24 @@ namespace EpicLoot.Crafting
             {
                 var availableEffects = AugmentTabController.GetAvailableAugments(recipe, item, magicItem, rarity);
                 var t = new StringBuilder();
+                if (availableEffects.Count < 20)
+                {
+                    Description.resizeTextForBestFit = true;
+                    Description.fontSize = 18;
+                }
+                else
+                {
+                    Description.resizeTextForBestFit = false;
+                    Description.fontSize = 12;
+                }
+
                 foreach (var effectDef in availableEffects)
                 {
                     var values = effectDef.GetValuesForRarity(item.GetRarity());
                     var valueDisplay = values != null ? Mathf.Approximately(values.MinValue, values.MaxValue) ? $"{values.MinValue}" : $"({values.MinValue}-{values.MaxValue})" : "";
                     t.AppendLine($"‣ {string.Format(Localization.instance.Localize(effectDef.DisplayText), valueDisplay)}");
                 }
-
+                
                 Description.color = rarityColor;
                 Description.text = t.ToString();
             }


### PR DESCRIPTION
Adjusting Available Augments to resize if the number of augments available is longer than the provided Text box in Non-Auga UI's.

Fixes #463 

(cherry picked from commit b382c8aea4efd231e147152061bb912c8aa3bde2)