### PR TITLE
Changing this to GetorCreate to ensure that we have an item returned.

### DIFF
--- a/EpicLoot/MagicItemComponent.cs
+++ b/EpicLoot/MagicItemComponent.cs
@@ -197,8 +197,8 @@ namespace EpicLoot
 
         public static ItemDrop.ItemData Extended(this ItemDrop.ItemData itemData)
         {
-            var value = itemData.Data().Get<MagicItemComponent>();
-            return value?.Item;
+            var value = itemData.Data().GetOrCreate<MagicItemComponent>();
+            return value.Item;
         }
 
         public static MagicItem GetMagicItem(this ItemDrop.ItemData itemData)


### PR DESCRIPTION
Originally we talked about removing it, but I think it's OK to leave it as is.  I've changed it to GetorCreate so that it will always return the Item back to that method (and not be null).

Part of it, is that it keeps some of that integration code in one spot for future overhaul, should it need it.  The other part of it is, that I like the simplicity of `.Extended` where used in the rest of the code.