### PR TITLE
Unrestricting the HotkeyBar action

### DIFF
--- a/EpicLoot/MagicItemComponent.cs
+++ b/EpicLoot/MagicItemComponent.cs
@@ -800,7 +800,7 @@ namespace EpicLoot
         public static void Postfix(HotkeyBar __instance, List<HotkeyBar.ElementData> ___m_elements, List<ItemDrop.ItemData> ___m_items, Player player)
         {
 
-            if (!__instance.name.Equals("HotKeyBar") || player == null || player.IsDead()) return;
+            if ( player == null || player.IsDead()) return;
 
             for (var index = 0; index < Player.m_localPlayer.GetInventory().m_width; index++)
             {


### PR DESCRIPTION
This restores the background highlighting on the Quick Slot bar (or other bars in use by other mods)