### PR TITLE
Turn all of the lights in Dverger Circlet on/off

### DIFF
--- a/DvergerColor/VisEquipment_Patch.cs
+++ b/DvergerColor/VisEquipment_Patch.cs
@@ -17,6 +17,7 @@ namespace DvergerColor
         private float _pointIntensity = 1.1f;
         private float _pointRange = 10;
         private Light _light;
+        private Light[] _lights;
 
         public int Step;
         public bool On;
@@ -91,19 +92,22 @@ namespace DvergerColor
 
             var inBed = player.InBed();
             var turnOffInBed = DvergerColor.TurnOffInBed.Value;
-            if (turnOffInBed && inBed)
-            {
-                _light.enabled = false;
-            }
-            else
-            {
-                _light.enabled = On;
+            foreach (Light light in _lights) {
+                if (turnOffInBed && inBed)
+                {
+                    light.enabled = false;
+                }
+                else
+                {
+                    light.enabled = On;
+                }
             }
         }
 
-        public void SetLight(Light light)
+        public void SetLights(Light[] lights)
         {
-            _light = light;
+            _lights = lights;
+            _light = lights[0];
             if (_light != null)
             {
                 _light.color = DvergerColor.Color.Value;
@@ -157,11 +161,11 @@ namespace DvergerColor
                 Object.Destroy(__result.GetComponent<LightChanger>());
             }
 
-            var light = __result.GetComponentInChildren<Light>();
+            var lights = __result.GetComponentsInChildren<Light>();
 
-            if (light != null)
+            if (lights.Length > 0)
             {
-                __result.AddComponent<LightChanger>().SetLight(light);
+                __result.AddComponent<LightChanger>().SetLights(lights);
             }
         }
     }


### PR DESCRIPTION
Dverger circlet contains more than one light components. When switching them on/off, apply enabled state to all light components.