### PR TITLE
Check for Haldor in Trader object prior to opening up store.

### DIFF
--- a/EpicLoot/Adventure/StoreGui_Patch.cs
+++ b/EpicLoot/Adventure/StoreGui_Patch.cs
@@ -12,8 +12,14 @@ namespace EpicLoot.Adventure
         [HarmonyPostfix]
         public static void Show_Postfix(StoreGui __instance)
         {
-            if (!EpicLoot.IsAdventureModeEnabled())
+            if (!EpicLoot.IsAdventureModeEnabled() || __instance == null)
             {
+                return;
+            }
+
+            if (__instance.m_trader.m_name != "$npc_haldor")
+            {
+                //Adds compatibility for other mods that may add other trader NPC's that are not Haldor.
                 return;
             }
 


### PR DESCRIPTION
This came in as a community request from another mod author who's mod creates multiple different NPC "Traders" across the Valheim world.  Epic Loot was opening up on every trader NPC, instead of just Haldor.

This limits the scope of EpicLoot to only open when interacting with Haldor.