### PR TITLE
EquipFx's Turn Off When Moved In Inventory

### DIFF
--- a/EpicLoot/VisEquipment_Patch.cs
+++ b/EpicLoot/VisEquipment_Patch.cs
@@ -214,9 +214,9 @@ namespace EpicLoot
 
         [HarmonyPatch(typeof(Humanoid), nameof(Humanoid.UnequipItem))]
         [HarmonyPrefix]
-        public static void Humanoid_UnequipItem_Prefix(Humanoid __instance, ItemDrop.ItemData item)
+        public static void Humanoid_UnequipItem_Prefix(Humanoid __instance, ItemDrop.ItemData item, bool triggerEquipEffects)
         {
-            if (item == null || !item.m_equiped)
+            if (item == null || !item.m_equiped || !triggerEquipEffects)
             {
                 return;
             }


### PR DESCRIPTION
The InventoryGui.OnSelectedItem does an Unequip and an Equip when moving equipped armor around.  There's a flag that disables equipment effects so that it doesn't process changes.

Adding a check, and if TriggerEffects is false, then it's going to skip the Unequip action.