### PR TITLE
EAQS Keybinding Issue

### DIFF
--- a/EquipmentAndQuickSlots/EquipmentAndQuickSlots.cs
+++ b/EquipmentAndQuickSlots/EquipmentAndQuickSlots.cs
@@ -152,7 +152,11 @@ namespace EquipmentAndQuickSlots
         public static string GetBindingKeycode(int index)
         {
             index = Mathf.Clamp(index, 0, QuickSlotCount - 1);
-            return KeyCodes[index] == null ? null : KeyCodes[index].Value.ToLowerInvariant();
+            var keycodeValue = KeyCodes[index].Value.ToLowerInvariant();
+            if (keycodeValue.IsNullOrWhiteSpace())
+                return null;
+
+            return keycodeValue;
         }
 
         public static void CheckQuickUseInput(Player player, int index)


### PR DESCRIPTION
When the keybinding in EAQS goes missing, this method doesn't return the proper value, it's not returning null, but it wasn't returning a keycode either.

string.Empty throws errors downstream.