### PR TITLE
Equipment and Quick Slots Release v2.1.3

### DIFF
--- a/EquipmentAndQuickSlots/CHANGELOG.md
+++ b/EquipmentAndQuickSlots/CHANGELOG.md
@@ -1,0 +1,62 @@
+## Release 2.1.3
+  * Improved Controller Support Between Windows
+    * Known Bug: The weight calculation is still not working when using controller to transfer items.
+  * Rebuilt QuickSlotHotkeyBar from the Ground Up
+    * No longer a Prefix that blocks UpdateIcons
+    * Allows other mods to affect item icons in the Hotkeybar
+    * Potential for Performance Improvement
+## Release 2.1.2
+  * Updated for Valheim 0.214.2 Patch
+## Release 2.1.1
+  * Fixed compatibility issues with JewelCrafting and MultiUserChest
+## Release 2.1.0
+  * Updated for Mistlands!
+  * Now uses player.m_customData instead of knownTexts
+  * On death, drops equipment in second gravestone
+  * Fixed bug where you couldn't move items out of your quickslots
+  * Added new config features: DontDropEquipmentOnDeath, DontDropQuickslotsOnDeath, InstantlyReequipArmorOnPickup, InstantlyReequipQuickslotsOnPickup
+
+### Archieved Change Log:
+* 1.0.3
+    * Integrated fix for larger containers (this mod was not allowing the same row to be used in containers as it uses in the Inventory)
+* 1.0.4
+    * Fixed issue where gamepad could not use quick slots
+* 1.0.5
+    * Fixed issue where the previous fix broke the #8 hotkey...
+* 2.0.0 Stability Update
+    * Items are saved even if accidentally uninstalling or having an error
+    * UIs work better with controller
+    * Never drop or lose items on death
+* 2.0.1
+    * Hotfix for not being able to craft when fully equipped
+* 2.0.2
+    * Fixed an issue where some equipment was lost on death
+    * Re-added the toggles to disable and enable features
+* 2.0.3
+    * Fixed a bug where players could teleport with items they normally can't
+* 2.0.4
+    * Fixed gamepad navigation for the crafting recipe list
+    * Fixed bug preventing new characters from being created
+* 2.0.5
+    * Put in a potential fix for "losing items" on tombstone pickup (they're in your inventory, just outside the grid. This version should fix that.)
+* 2.0.6
+    * Fix for double upgrade when using EpicLoot with EAQS
+    * Fix for items lost in tombstone by [jsza](https://github.com/jsza).
+* 2.0.7
+    * (This entire update provided by [jsza](https://github.com/jsza))
+    * Fix a variety of equipment bugs
+    * Fix a variety of pickup/stacking bugs
+* 2.0.8
+    * Had to update the number to re-upload to ThunderStore
+* 2.0.9
+    * Quick slots position is now configurable
+* 2.0.10
+    * Fixed an encumberance bug
+* 2.0.11
+    * Added support for Project Auga
+* 2.0.12
+    * Better Valheim+ and Auga positioning for the inventory
+* 2.0.14
+    * Updated for H&H
+* 2.0.15
+    * Yet Another Attempt at fixing the lost-equipment-on-death bug

--- a/EquipmentAndQuickSlots/CHANGELOG.md
+++ b/EquipmentAndQuickSlots/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Release 2.1.3
-  * Improved Controller Support Between Windows
+  * Improved Controller Support Between Hotbars/Inventories
     * Known Bug: The weight calculation is still not working when using controller to transfer items.
+  * Updated Keybindings to Support Controllers
   * Rebuilt QuickSlotHotkeyBar from the Ground Up
     * No longer a Prefix that blocks UpdateIcons
     * Allows other mods to affect item icons in the Hotkeybar (like EpicLoot)

--- a/EquipmentAndQuickSlots/CHANGELOG.md
+++ b/EquipmentAndQuickSlots/CHANGELOG.md
@@ -3,7 +3,7 @@
     * Known Bug: The weight calculation is still not working when using controller to transfer items.
   * Rebuilt QuickSlotHotkeyBar from the Ground Up
     * No longer a Prefix that blocks UpdateIcons
-    * Allows other mods to affect item icons in the Hotkeybar
+    * Allows other mods to affect item icons in the Hotkeybar (like EpicLoot)
     * Potential for Performance Improvement
 ## Release 2.1.2
   * Updated for Valheim 0.214.2 Patch

--- a/EquipmentAndQuickSlots/EquipmentAndQuickSlots.cs
+++ b/EquipmentAndQuickSlots/EquipmentAndQuickSlots.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 
 namespace EquipmentAndQuickSlots
 {
-    [BepInPlugin(PluginId, "Equipment and Quick Slots", "2.1.2")]
+    [BepInPlugin(PluginId, "Equipment and Quick Slots", "2.1.3")]
     [BepInDependency("moreslots", BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency("randyknapp.mods.auga", BepInDependency.DependencyFlags.SoftDependency)]
     public class EquipmentAndQuickSlots : BaseUnityPlugin

--- a/EquipmentAndQuickSlots/EquipmentAndQuickSlots.csproj
+++ b/EquipmentAndQuickSlots/EquipmentAndQuickSlots.csproj
@@ -115,6 +115,7 @@
       <Link>AugaAPI.dll</Link>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Resource>
+    <Content Include="CHANGELOG.md" />
     <Content Include="ILRepack.targets">
       <SubType>Designer</SubType>
     </Content>

--- a/EquipmentAndQuickSlots/ExtendedInventory.cs
+++ b/EquipmentAndQuickSlots/ExtendedInventory.cs
@@ -35,7 +35,7 @@ namespace EquipmentAndQuickSlots
 
         public ExtendedInventory(Player player, string name, Sprite bkg, int w, int h) : base(name, bkg, w, h)
         {
-            EquipmentAndQuickSlots.LogWarning("New Extended Inventory for Player");
+            //EquipmentAndQuickSlots.LogWarning("New Extended Inventory for Player");
             _player = player;
         }
 
@@ -75,7 +75,7 @@ namespace EquipmentAndQuickSlots
 
                 if (inventory.AddItem(item))
                 {
-                    EquipmentAndQuickSlots.LogWarning($"Added item ({item.m_shared.m_name}) to ({inventory.m_name}) at ({item.m_gridPos})");
+                    //EquipmentAndQuickSlots.LogWarning($"Added item ({item.m_shared.m_name}) to ({inventory.m_name}) at ({item.m_gridPos})");
                     OverrideUpdateTotalWeight();
                     result = true;
                     break;

--- a/EquipmentAndQuickSlots/HotkeyBar_Patch.cs
+++ b/EquipmentAndQuickSlots/HotkeyBar_Patch.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Reflection.Emit;
 using Common;
 using HarmonyLib;
+using JetBrains.Annotations;
 using UnityEngine;
 using UnityEngine.UI;
 using Object = UnityEngine.Object;
@@ -13,114 +15,129 @@ namespace EquipmentAndQuickSlots
         [HarmonyPatch(typeof(HotkeyBar), "UpdateIcons")]
         public static class HotkeyBar_UpdateIcons_Patch
         {
-            public static bool Prefix(HotkeyBar __instance, Player player)
+            public static void UpdateIcons(HotkeyBar instance, Player player, List<ItemDrop.ItemData> m_items)
             {
-                if (__instance.name != "QuickSlotsHotkeyBar")
+                if (instance.name != "QuickSlotsHotkeyBar")
                 {
-                    return true;
+                    return;
+                }
+                
+                player.GetQuickSlotInventory().GetBoundItems(m_items);
+            }
+            public static int UpdateIconCount(int defaultCount, HotkeyBar instance)
+            {
+                if (instance.name != "QuickSlotsHotkeyBar")
+                {
+                    return defaultCount;
+                }
+                
+                return EquipmentAndQuickSlots.QuickSlotCount;
+            }
+            public static void UpdateIconBinding(HotkeyBar instance, int index, HotkeyBar.ElementData elementData)
+            {
+                if (instance.name != "QuickSlotsHotkeyBar")
+                {
+                    return;
+                }
+                
+                var bindingText = elementData.m_go.transform.Find("binding").GetComponent<Text>();
+                bindingText.enabled = true;
+                bindingText.horizontalOverflow = HorizontalWrapMode.Overflow;
+                bindingText.text = EquipmentAndQuickSlots.GetBindingLabel(index);
+            }
+            [UsedImplicitly]
+            public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+            {
+                var instrs = instructions.ToList();
+
+                var counter = 0;
+
+                CodeInstruction LogMessage(CodeInstruction instruction)
+                {
+                    //EquipmentAndQuickSlots.LogWarning($"IL_{counter}: Opcode: {instruction.opcode} Operand: {instruction.operand}");
+                    return instruction;
                 }
 
-                if (player == null || player.IsDead())
+                var boundItemsMethod = AccessTools.DeclaredMethod(typeof(Inventory), nameof(Inventory.GetBoundItems));
+                var itemsListField = AccessTools.DeclaredField(typeof(HotkeyBar), nameof(HotkeyBar.m_items));
+                var setTextProperty = AccessTools.PropertySetter(typeof(Text), "text");
+
+                for (int i = 0; i < instrs.Count; ++i)
                 {
-                    foreach (var element in __instance.m_elements)
-                    {
-                        Object.Destroy(element.m_go);
-                    }
 
-                    __instance.m_elements.Clear();
-                }
-                else
-                {
-                    player.GetQuickSlotInventory().GetBoundItems(__instance.m_items);
-                    __instance.m_items.Sort((x, y) => x.m_gridPos.x.CompareTo(y.m_gridPos.x));
-                    const int showElementCount = EquipmentAndQuickSlots.QuickSlotCount;
-                    if (__instance.m_elements.Count != showElementCount)
+                    yield return LogMessage(instrs[i]);
+                    counter++;
+                    
+                    if (i > 6 && instrs[i].opcode == OpCodes.Callvirt && instrs[i].operand.Equals(boundItemsMethod))
                     {
-                        foreach (var element in __instance.m_elements)
+                        //Load LdArg0
+                        var ldArgInstruction = new CodeInstruction(OpCodes.Ldarg_0);
+                        //Move Any Labels from the instruction position being patched to new instruction.
+                        if (instrs[i].labels.Count > 0)
                         {
-                            Object.Destroy(element.m_go);
+                            instrs[i].MoveLabelsTo(ldArgInstruction);
                         }
 
-                        __instance.m_elements.Clear();
-                        for (var index = 0; index < showElementCount; ++index)
-                        {
-                            var elementData = new HotkeyBar.ElementData()
-                            {
-                                m_go = Object.Instantiate(__instance.m_elementPrefab, __instance.transform)
-                            };
-                            elementData.m_go.transform.localPosition = new Vector3(index * __instance.m_elementSpace, 0.0f, 0.0f);
-                            elementData.m_icon = elementData.m_go.transform.transform.Find("icon").GetComponent<Image>();
-                            elementData.m_durability = elementData.m_go.transform.Find("durability").GetComponent<GuiBar>();
-                            elementData.m_amount = elementData.m_go.transform.Find("amount").GetComponent<Text>();
-                            elementData.m_equiped = elementData.m_go.transform.Find("equiped").gameObject;
-                            elementData.m_queued = elementData.m_go.transform.Find("queued").gameObject;
-                            elementData.m_selection = elementData.m_go.transform.Find("selected").gameObject;
-
-                            var bindingText = elementData.m_go.transform.Find("binding").GetComponent<Text>();
-                            bindingText.enabled = true;
-                            bindingText.horizontalOverflow = HorizontalWrapMode.Overflow;
-                            bindingText.text = EquipmentAndQuickSlots.GetBindingLabel(index);
-
-                            __instance.m_elements.Add(elementData);
-                        }
-                    }
-
-                    foreach (var element in __instance.m_elements)
+                        //LdArg0
+                        yield return LogMessage(ldArgInstruction);
+                        counter++;
+                        
+                        //Player
+                        yield return LogMessage(new CodeInstruction(OpCodes.Ldarg_1));
+                        counter++;
+                        
+                        //this
+                        yield return LogMessage(new CodeInstruction(OpCodes.Ldarg_0));
+                        counter++;
+                        
+                        //this.m_items
+                        yield return LogMessage(new CodeInstruction(OpCodes.Ldfld, itemsListField));
+                        counter++;
+                        
+                        //Call Method
+                        yield return LogMessage(new CodeInstruction(OpCodes.Call, AccessTools.DeclaredMethod(typeof(HotkeyBar_UpdateIcons_Patch), nameof(UpdateIcons))));
+                        counter++;
+                    } 
+                    else if (i > 6 && instrs[i].opcode == OpCodes.Ldc_I4_0 && instrs[i+1].opcode == OpCodes.Stloc_0)
                     {
-                        element.m_used = false;
+                        //this
+                        yield return LogMessage(new CodeInstruction(OpCodes.Ldarg_0));
+                        counter++;
+                        
+                        //Call Method
+                        yield return LogMessage(new CodeInstruction(OpCodes.Call, AccessTools.DeclaredMethod(typeof(HotkeyBar_UpdateIcons_Patch), nameof(UpdateIconCount))));
+                        counter++;
                     }
-
-                    var isGamepadActive = ZInput.IsGamepadActive();
-                    foreach (var itemData in __instance.m_items)
+                    else if (i > 6 && instrs[i].opcode == OpCodes.Callvirt && instrs[i].operand.Equals(setTextProperty) 
+                             && instrs[i-1].opcode == OpCodes.Call && instrs[i-9].opcode == OpCodes.Ldstr && instrs[i-9].operand.Equals("binding"))
                     {
-                        var element = __instance.m_elements[itemData.m_gridPos.x];
-                        element.m_used = true;
-                        element.m_icon.gameObject.SetActive(true);
-                        element.m_icon.sprite = itemData.GetIcon();
-                        element.m_durability.gameObject.SetActive(itemData.m_shared.m_useDurability);
-                        if (itemData.m_shared.m_useDurability)
-                        {
-                            if (itemData.m_durability <= 0.0)
-                            {
-                                element.m_durability.SetValue(1f);
-                                element.m_durability.SetColor((double) Mathf.Sin(Time.time * 10f) > 0.0 ? Color.red : new Color(0.0f, 0.0f, 0.0f, 0.0f));
-                            }
-                            else
-                            {
-                                element.m_durability.SetValue(itemData.GetDurabilityPercentage());
-                                element.m_durability.ResetColor();
-                            }
-                        }
+                        var indexOperand = instrs[i-6].opcode == OpCodes.Ldloc_S ? instrs[i-6].operand : null;
+                        var elementDataOperand = instrs[i+1].opcode == OpCodes.Ldloc_S ? instrs[i+1].operand : null;
 
-                        element.m_equiped.SetActive(itemData.m_equiped);
-                        element.m_queued.SetActive(player.IsEquipActionQueued(itemData));
-                        if (itemData.m_shared.m_maxStackSize > 1)
+                        if (indexOperand != null)
                         {
-                            element.m_amount.gameObject.SetActive(true);
-                            element.m_amount.text = itemData.m_stack.ToString() + "/" + itemData.m_shared.m_maxStackSize.ToString();
+                            //this
+                            yield return LogMessage(new CodeInstruction(OpCodes.Ldarg_0));
+                            counter++;
+                        
+                            //index
+                            yield return LogMessage(new CodeInstruction(OpCodes.Ldloc_S, indexOperand));
+                            counter++;
+                        
+                            //elementData
+                            yield return LogMessage(new CodeInstruction(OpCodes.Ldloc_S, elementDataOperand));
+                            counter++;
+                        
+                            //Call Method
+                            yield return LogMessage(new CodeInstruction(OpCodes.Call, AccessTools.DeclaredMethod(typeof(HotkeyBar_UpdateIcons_Patch), nameof(UpdateIconBinding))));
+                            counter++;
                         }
                         else
                         {
-                            element.m_amount.gameObject.SetActive(false);
-                        }
-                    }
-
-                    for (var index = 0; index < __instance.m_elements.Count; ++index)
-                    {
-                        var element = __instance.m_elements[index];
-                        element.m_selection.SetActive(isGamepadActive && index == __instance.m_selected);
-                        if (!element.m_used)
-                        {
-                            element.m_icon.gameObject.SetActive(false);
-                            element.m_durability.gameObject.SetActive(false);
-                            element.m_equiped.SetActive(false);
-                            element.m_queued.SetActive(false);
-                            element.m_amount.gameObject.SetActive(false);
+                            EquipmentAndQuickSlots.LogError($"Can't Find Index Operand !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
                         }
                     }
                 }
-
-                return false;
             }
         }
     }

--- a/EquipmentAndQuickSlots/InventoryGui_Patch.cs
+++ b/EquipmentAndQuickSlots/InventoryGui_Patch.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;
 using JetBrains.Annotations;

--- a/EquipmentAndQuickSlots/InventoryGui_Patch.cs
+++ b/EquipmentAndQuickSlots/InventoryGui_Patch.cs
@@ -294,16 +294,6 @@ namespace EquipmentAndQuickSlots
                 return instance.m_activeGroup != instance.m_uiGroups.Length - 1;
             }
         }
-
-        //public void UpdateRecipeGamepadInput()
-        [HarmonyPatch(typeof(InventoryGui), "UpdateRecipeGamepadInput")]
-        public static class InventoryGui_UpdateRecipeGamepadInput_Patch
-        {
-            public static bool Prefix(InventoryGui __instance)
-            {
-                return __instance.m_activeGroup == __instance.m_uiGroups.Length - 1;
-            }
-        }
     }
 
     // Bugfix: Upgrading doesn't properly check if you have an empty space, so no more unequipping

--- a/EquipmentAndQuickSlots/InventoryGui_Patch.cs
+++ b/EquipmentAndQuickSlots/InventoryGui_Patch.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;
+using JetBrains.Annotations;
 using UnityEngine;
 using UnityEngine.UI;
 using Object = UnityEngine.Object;
@@ -245,33 +246,52 @@ namespace EquipmentAndQuickSlots
             }
         }
 
-        [HarmonyPatch(typeof(InventoryGui), "UpdateGamepad")]
+        
+        [HarmonyPatch(typeof(InventoryGui), nameof(InventoryGui.UpdateGamepad))]
         public static class InventoryGui_UpdateGamepad_Patch
         {
-            public static bool Prefix(InventoryGui __instance)
+            [UsedImplicitly]
+            public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator ilGenerator)
             {
-                if (!__instance.m_inventoryGroup.IsActive)
-                {
-                    return false;
-                }
-                if (ZInput.GetButtonDown("JoyTabLeft"))
-                {
-                    __instance.SetActiveGroup(__instance.m_activeGroup - 1);
-                }
-                if (ZInput.GetButtonDown("JoyTabRight"))
-                {
-                    __instance.SetActiveGroup(__instance.m_activeGroup + 1);
-                }
-                if (__instance.m_activeGroup == 0 && !__instance.IsContainerOpen())
-                {
-                    __instance.SetActiveGroup(1);
-                }
-                if (__instance.m_activeGroup == __instance.m_uiGroups.Length - 1)
-                {
-                    __instance.UpdateRecipeGamepadInput();
-                }
+                var activeGroupField = AccessTools.DeclaredField(typeof(InventoryGui), "m_activeGroup" );
+                
+                var instrs = instructions.ToList();
 
-                return false;
+                var counter = 0;
+                var skipLines = 0;
+
+                for (int i = 0; i < instrs.Count; ++i)
+                {
+                    if (i > 5 && instrs[i].opcode == OpCodes.Ldfld 
+                        && instrs[i].operand.Equals(activeGroupField) && instrs[i + 1].opcode == OpCodes.Ldc_I4_3 
+                        && instrs[i + 2].opcode == OpCodes.Bne_Un)
+                    {
+                        //Replace Field with Call
+                        yield return EquipmentAndQuickSlots.LogMessage(new CodeInstruction(OpCodes.Call, AccessTools.DeclaredMethod(typeof(InventoryGui_UpdateGamepad_Patch), nameof(GetMaxUiGroups))),counter);
+                        counter++;
+                        
+                        //Remove ldc_i4.3
+                        skipLines++;
+                        
+                        //Create new BrTrue
+                        yield return EquipmentAndQuickSlots.LogMessage(new CodeInstruction(OpCodes.Brtrue, instrs[i +2].operand), counter);
+                        
+                        //Remove Bne
+                        skipLines++;
+
+                        i += skipLines;
+                    }
+                    else
+                    {
+                        yield return EquipmentAndQuickSlots.LogMessage(instrs[i], counter);
+                        counter++;
+                    }
+                }
+            }
+
+            public static bool GetMaxUiGroups(InventoryGui instance)
+            {
+                return instance.m_activeGroup != instance.m_uiGroups.Length - 1;
             }
         }
 

--- a/EquipmentAndQuickSlots/PlayerExtensions.cs
+++ b/EquipmentAndQuickSlots/PlayerExtensions.cs
@@ -37,7 +37,7 @@ namespace EquipmentAndQuickSlots
                 return;
             }
 
-            EquipmentAndQuickSlots.LogWarning("Saving ExtendedPlayerData");
+            //EquipmentAndQuickSlots.LogWarning("Saving ExtendedPlayerData");
             SaveValue(_player, "ExtendedPlayerData", "This player is using ExtendedPlayerData!");
 
             var pkg = new ZPackage();
@@ -59,7 +59,7 @@ namespace EquipmentAndQuickSlots
 
             _player = fromPlayer;
             LoadValue(fromPlayer, "ExtendedPlayerData", out var init);
-            EquipmentAndQuickSlots.LogWarning("Loaded ExtendedPlayerData");
+            //EquipmentAndQuickSlots.LogWarning("Loaded ExtendedPlayerData");
 
             if (LoadValue(fromPlayer, nameof(QuickSlotInventory), out var quickSlotData))
             {

--- a/EquipmentAndQuickSlots/Properties/AssemblyInfo.cs
+++ b/EquipmentAndQuickSlots/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.2")]
-[assembly: AssemblyFileVersion("2.1.2")]
+[assembly: AssemblyVersion("2.1.3")]
+[assembly: AssemblyFileVersion("2.1.3")]

--- a/EquipmentAndQuickSlots/README.md
+++ b/EquipmentAndQuickSlots/README.md
@@ -3,7 +3,7 @@ The new, v2.1 of Equipment and Quick Slots does not need to be installed on serv
 
 Please report bugs on our discord: https://discord.gg/ZNhYeavv3C
 
-# Equipment and Quick Slots v2.1.1
+# Equipment and Quick Slots v2.1.3
 ##### by RandyKnapp
 Give equipped items their own dedicated inventory slots, plus three more hotkeyable quick slots.
 

--- a/EquipmentAndQuickSlots/manifest.json
+++ b/EquipmentAndQuickSlots/manifest.json
@@ -1,7 +1,9 @@
 {
   "name": "EquipmentAndQuickSlots",
-  "version_number": "2.1.1",
+  "version_number": "2.1.3",
   "website_url": "https://github.com/RandyKnapp/ValheimMods/tree/main/EquipmentAndQuickSlots",
   "description": "Give equipped items their own dedicated inventory slots, plus three more hotkeyable quick slots.",
-  "dependencies": []
+  "dependencies": [
+    "denikson-BepInExPack_Valheim-5.4.2102"
+  ]
 }


### PR DESCRIPTION
## Release 2.1.3
  * Improved Controller Support Between Hotbars/Inventories
    * Known Bug: The weight calculation is still not working when using a controller to transfer items.
  * Updated Keybindings to Support Controllers
  * Rebuilt QuickSlotHotkeyBar from the Ground Up
    * No longer a Prefix that blocks UpdateIcons
    * Allows other mods to affect item icons in the Hotkeybar (like EpicLoot)
    * Potential for Performance Improvement