### PR TITLE
EpicLoot and Other Mod Releases

### DIFF
--- a/EpicLoot/Adventure/AdventureDataManager.cs
+++ b/EpicLoot/Adventure/AdventureDataManager.cs
@@ -42,7 +42,7 @@ namespace EpicLoot.Adventure
                     if (characterDrop != null)
                     {
                         var drops = characterDrop.m_drops.Select(x => x.m_prefab.GetComponent<ItemDrop>());
-                        var trophyPrefab = drops.FirstOrDefault(x => x.m_itemData.m_shared.m_itemType == ItemDrop.ItemData.ItemType.Trophie);
+                        var trophyPrefab = drops.FirstOrDefault(x => x.m_itemData.m_shared.m_itemType == ItemDrop.ItemData.ItemType.Trophy);
                         if (trophyPrefab != null)
                         {
                             sprite = trophyPrefab.m_itemData.GetIcon();

--- a/EpicLoot/Adventure/AdventureSaveData.cs
+++ b/EpicLoot/Adventure/AdventureSaveData.cs
@@ -124,7 +124,6 @@ namespace EpicLoot.Adventure
             }
 
             result.Slain = pkg.ReadBool();
-
             return result;
         }
 

--- a/EpicLoot/Adventure/BountyTarget.cs
+++ b/EpicLoot/Adventure/BountyTarget.cs
@@ -51,7 +51,6 @@ namespace EpicLoot.Adventure
 
         private void OnDeath()
         {
-            EpicLoot.LogWarning("BountyTarget.OnDeath");
             if (ZNet.instance.IsServer() || !ZNet.instance.IsServer() && !ZNet.instance.IsDedicated())
             {
                 var pkg = new ZPackage();
@@ -156,15 +155,18 @@ namespace EpicLoot.Adventure
         }
     }
 
+    [HarmonyPatch(typeof(Humanoid), nameof(Humanoid.Start))]
     [HarmonyPatch(typeof(Character), nameof(Character.Start))]
     public static class Character_Start_Patch
     {
         public static void Postfix(Character __instance)
         {
             var zdo = __instance.m_nview != null ? __instance.m_nview.GetZDO() : null;
+
             if (zdo != null && zdo.IsValid())
             {
                 var old = !string.IsNullOrEmpty(zdo.GetString("BountyTarget"));
+
                 if (old)
                 {
                     EpicLoot.LogWarning($"Destroying old bounty target: {__instance.name}");

--- a/EpicLoot/Adventure/Feature/Bounties.cs
+++ b/EpicLoot/Adventure/Feature/Bounties.cs
@@ -228,7 +228,6 @@ namespace EpicLoot.Adventure.Feature
             {
                 var prefab = prefabs[index];
                 var isAdd = index > 0;
-
                 var creature = Object.Instantiate(prefab, spawnPoint, Quaternion.identity);
                 var bountyTarget = creature.AddComponent<BountyTarget>();
                 bountyTarget.Initialize(bounty, prefab.name, isAdd);

--- a/EpicLoot/CHANGELOG.md
+++ b/EpicLoot/CHANGELOG.md
@@ -1,5 +1,12 @@
-﻿## Version 0.9.13 - Valheim Update 0.216.7
-* Required updates for Valheim version 0.216.7
+## Version 0.9.15 - Valheim Update 0.216.9 - Part 3
+* Updated `enchantcosts.json` with the corrected spelling of Trophy (from Trophie).
+* Fixed issue with bounties not working correctly after update to 0.9.14.
+
+## Version 0.9.14 - Valheim Update 0.216.9 - Part 2
+* Left a piece out that needed to be updated with regards to `CopyCustomDataFromUpgradedItem`
+
+## Version 0.9.13 - Valheim Update 0.216.9
+* Required updates for Valheim version 0.216.9
 
 ## Version 0.9.12 - More Performance Improvements and Bugfixes
 * Reduced the frequency that Multiplayer send Legendary Info

--- a/EpicLoot/CHANGELOG.md
+++ b/EpicLoot/CHANGELOG.md
@@ -1,9 +1,12 @@
+﻿## Version 0.9.13 - Valheim Update 0.216.7
+* Required updates for Valheim version 0.216.7
+
 ## Version 0.9.12 - More Performance Improvements and Bugfixes
 * Reduced the frequency that Multiplayer send Legendary Info
-  * Improves frame rates when near others.
+    * Improves frame rates when near others.
 * Slightly improved performance of Loot Beams
 * Fixed HotkeyBar Icons Updating
-  * Now updates background when items removed.
+    * Now updates background when items removed.
 
 ## Version 0.9.11 - Performance Improvements
 * Rebuilt the way Map Pins are maintained for Treasures and Bounties.

--- a/EpicLoot/CharacterDrop_Patch.cs
+++ b/EpicLoot/CharacterDrop_Patch.cs
@@ -93,7 +93,7 @@ namespace EpicLoot
                         continue;
                     }
 
-                    if (itemDrop.m_itemData.m_shared.m_itemType == ItemDrop.ItemData.ItemType.Trophie)
+                    if (itemDrop.m_itemData.m_shared.m_itemType == ItemDrop.ItemData.ItemType.Trophy)
                     {
                         int dropCount;
                         var playerList = ZNet.instance.GetPlayerList();

--- a/EpicLoot/Crafting/DisenchantTabController.cs
+++ b/EpicLoot/Crafting/DisenchantTabController.cs
@@ -110,7 +110,7 @@ namespace EpicLoot.Crafting
                 var itemData = recipe.FromItem;
 
                 var canPutProductsInInventory = CanAddItems(player.GetInventory(), recipe.Products, 1);
-                var isEquipped = recipe.FromItem.m_equiped;
+                var isEquipped = recipe.FromItem.m_equipped;
                 var canCraft = canPutProductsInInventory && !isEquipped;
                 var tooltip = Localization.instance.Localize(canPutProductsInInventory ? (isEquipped ? "$mod_epicloot_sacrifice_equipped" : "") : "$inventory_full");
 
@@ -431,7 +431,7 @@ namespace EpicLoot.Crafting
                 {
                     if (!EpicLoot.ShowEquippedAndHotbarItemsInSacrificeTab.Value)
                     {
-                        if (item != null && item.m_equiped || boundItems.Contains(item))
+                        if (item != null && item.m_equipped || boundItems.Contains(item))
                         {
                             continue;
                         }
@@ -455,7 +455,7 @@ namespace EpicLoot.Crafting
                 return 3;
             }
 
-            if (recipe.FromItem.m_shared.m_itemType == ItemDrop.ItemData.ItemType.Trophie)
+            if (recipe.FromItem.m_shared.m_itemType == ItemDrop.ItemData.ItemType.Trophy)
             {
                 return recipe.Products.Exists(x => x.Key.m_itemData.IsRunestone()) ? 1 : 0;
             }

--- a/EpicLoot/CraftingV2/EnchantingUIController.cs
+++ b/EpicLoot/CraftingV2/EnchantingUIController.cs
@@ -109,7 +109,7 @@ namespace EpicLoot.CraftingV2
             {
                 if (!EpicLoot.ShowEquippedAndHotbarItemsInSacrificeTab.Value)
                 {
-                    if (item != null && item.m_equiped || boundItems.Contains(item))
+                    if (item != null && item.m_equipped || boundItems.Contains(item))
                         continue;
                 }
 
@@ -570,7 +570,7 @@ namespace EpicLoot.CraftingV2
             var boundItems = new List<ItemDrop.ItemData>();
             inventory.GetBoundItems(boundItems);
             return Player.m_localPlayer.GetInventory().GetAllItems()
-                .Where(item => !item.m_equiped && (EpicLoot.ShowEquippedAndHotbarItemsInSacrificeTab.Value || !boundItems.Contains(item)))
+                .Where(item => !item.m_equipped && (EpicLoot.ShowEquippedAndHotbarItemsInSacrificeTab.Value || !boundItems.Contains(item)))
                 .Where(item => item.IsMagic(out var magicItem) && magicItem.CanBeDisenchanted())
                 .Select(item => new InventoryItemListElement() { Item = item })
                 .ToList();

--- a/EpicLoot/Data/CustomDataManager.cs
+++ b/EpicLoot/Data/CustomDataManager.cs
@@ -628,18 +628,20 @@ namespace EpicLoot.Data
 			{
 				ZNetView netView = item.GetComponent<ZNetView>();
 				ZDO? zdo = netView && netView.IsValid() ? netView.GetZDO() : null;
-				if (zdo?.m_ints?.ContainsKey("dataCount".GetStableHashCode()) != true)
+				if (zdo == null) return;
+				
+				var containsDataCount = ZDOExtraData.s_ints[zdo.m_uid].ContainsKey("dataCount".GetStableHashCode());
+				
+				if (containsDataCount != true)
 				{
 					item.m_itemData.m_customData = new Dictionary<string, string>(prefab.GetComponent<ItemDrop>().m_itemData.m_customData);
-					if (zdo is not null)
+
+					int num = 0;
+					zdo.Set("dataCount", item.m_itemData.m_customData.Count);
+					foreach (KeyValuePair<string, string> keyValuePair in item.m_itemData.m_customData)
 					{
-						int num = 0;
-						zdo.Set("dataCount", item.m_itemData.m_customData.Count);
-						foreach (KeyValuePair<string, string> keyValuePair in item.m_itemData.m_customData)
-						{
-							zdo.Set($"data_{num}", keyValuePair.Key);
-							zdo.Set($"data__{num++}", keyValuePair.Value);
-						}
+						zdo.Set($"data_{num}", keyValuePair.Key);
+						zdo.Set($"data__{num++}", keyValuePair.Value);
 					}
 				}
 			}

--- a/EpicLoot/EpicLoot.cs
+++ b/EpicLoot/EpicLoot.cs
@@ -89,7 +89,7 @@ namespace EpicLoot
     {
         public const string PluginId = "randyknapp.mods.epicloot";
         public const string DisplayName = "Epic Loot";
-        public const string Version = "0.9.13";
+        public const string Version = "0.9.15";
 
         private readonly ConfigSync _configSync = new ConfigSync(PluginId) { DisplayName = DisplayName, CurrentVersion = Version, MinimumRequiredVersion = "0.9.11" };
 

--- a/EpicLoot/EpicLoot.cs
+++ b/EpicLoot/EpicLoot.cs
@@ -89,7 +89,7 @@ namespace EpicLoot
     {
         public const string PluginId = "randyknapp.mods.epicloot";
         public const string DisplayName = "Epic Loot";
-        public const string Version = "0.9.12";
+        public const string Version = "0.9.13";
 
         private readonly ConfigSync _configSync = new ConfigSync(PluginId) { DisplayName = DisplayName, CurrentVersion = Version, MinimumRequiredVersion = "0.9.11" };
 

--- a/EpicLoot/ItemDrop_Patch_MagicItemTooltip.cs
+++ b/EpicLoot/ItemDrop_Patch_MagicItemTooltip.cs
@@ -15,7 +15,7 @@ namespace EpicLoot
         public static bool Prefix(ItemDrop.ItemData item, UITooltip tooltip)
         {
             string tooltipText;
-            if (item.IsEquipable() && !item.m_equiped && Player.m_localPlayer != null && Player.m_localPlayer.HasEquipmentOfType(item.m_shared.m_itemType) && Input.GetKey(KeyCode.LeftControl))
+            if (item.IsEquipable() && !item.m_equipped && Player.m_localPlayer != null && Player.m_localPlayer.HasEquipmentOfType(item.m_shared.m_itemType) && Input.GetKey(KeyCode.LeftControl))
             {
                 var otherItem = Player.m_localPlayer.GetEquipmentOfType(item.m_shared.m_itemType);
                 tooltipText = item.GetTooltip() + $"\n\n<color=#AAA><i>$mod_epicloot_currentlyequipped:</i></color>\n<size=18>{otherItem.GetDecoratedName()}</size>\n" + otherItem.GetTooltip();

--- a/EpicLoot/LootRoller.cs
+++ b/EpicLoot/LootRoller.cs
@@ -806,7 +806,7 @@ namespace EpicLoot
 
         public static void DebugLuckFactor()
         {
-            var players = Player.m_players;
+            var players = Player.s_players;
             if (players != null)
             {
                 Debug.LogWarning($"DebugLuckFactor ({players.Count} players)");

--- a/EpicLoot/MagicItemComponent.cs
+++ b/EpicLoot/MagicItemComponent.cs
@@ -40,7 +40,7 @@ namespace EpicLoot
             if (Player.m_localPlayer == null)
                 return;
 
-            if (Item.m_equiped && Player.m_localPlayer.IsItemEquiped(Item))
+            if (Item.m_equipped && Player.m_localPlayer.IsItemEquiped(Item))
                 Multiplayer_Player_Patch.UpdatePlayerZDOForEquipment(Player.m_localPlayer, Item, MagicItem != null);
         }
 
@@ -679,7 +679,7 @@ namespace EpicLoot
 
         public static Player GetPlayerWithEquippedItem(ItemDrop.ItemData itemData)
         {
-            return Player.m_players.FirstOrDefault(player => player.IsItemEquiped(itemData));
+            return Player.s_players.FirstOrDefault(player => player.IsItemEquiped(itemData));
         }
     }
 

--- a/EpicLoot/MagicItemEffects/FeatherFall.cs
+++ b/EpicLoot/MagicItemEffects/FeatherFall.cs
@@ -23,12 +23,12 @@ namespace EpicLoot.MagicItemEffects
                 EquipmentEffectCache.Reset(player);
 
                 var shouldHaveFeatherFall = player.HasActiveMagicEffect(MagicEffectType.FeatherFall);
-                var hasFeatherFall = player.m_eqipmentStatusEffects.Contains(slowFall);
+                var hasFeatherFall = player.m_equipmentStatusEffects.Contains(slowFall);
                 if (!hasFeatherFall && shouldHaveFeatherFall)
                 {
-                    player.m_eqipmentStatusEffects.Add(slowFall);
+                    player.m_equipmentStatusEffects.Add(slowFall);
                     player.m_seman.AddStatusEffect(slowFall);
-                    var equipEffectsList = string.Join(", ", player.m_eqipmentStatusEffects.Select(x => x.name));
+                    var equipEffectsList = string.Join(", ", player.m_equipmentStatusEffects.Select(x => x.name));
                     EpicLoot.Log($"Adding feather fall. Current equip effects: {equipEffectsList}");
                 }
             }

--- a/EpicLoot/MagicItemEffects/ModifyAttackSpeed.cs
+++ b/EpicLoot/MagicItemEffects/ModifyAttackSpeed.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace EpicLoot.MagicItemEffects
 {
-    [HarmonyPatch(typeof(CharacterAnimEvent), nameof(CharacterAnimEvent.FixedUpdate))]
+    [HarmonyPatch(typeof(CharacterAnimEvent), nameof(CharacterAnimEvent.CustomFixedUpdate))]
     public static class ModifyAttackSpeed_CharacterAnimEvent_FixedUpdate_Patch
     {
         [UsedImplicitly]

--- a/EpicLoot/MagicItemEffects/ModifyStaggerDuration.cs
+++ b/EpicLoot/MagicItemEffects/ModifyStaggerDuration.cs
@@ -13,7 +13,7 @@ namespace EpicLoot.MagicItemEffects
         public const string ZdoKey = "el-sd";
     }
 
-    [HarmonyPatch(typeof(CharacterAnimEvent), nameof(CharacterAnimEvent.FixedUpdate))]
+    [HarmonyPatch(typeof(CharacterAnimEvent), nameof(CharacterAnimEvent.CustomFixedUpdate))]
     public static class ModifyStaggerDuration_CharacterAnimEvent_FixedUpdate_Patch
     {
         [UsedImplicitly]

--- a/EpicLoot/MagicItemEffects/Paralyze.cs
+++ b/EpicLoot/MagicItemEffects/Paralyze.cs
@@ -43,10 +43,10 @@ namespace EpicLoot.MagicItemEffects
                     return;
                 }
 
-                var seParalyze = __instance.m_seman.GetStatusEffect("Paralyze") as SE_Paralyzed;
+                var seParalyze = __instance.m_seman.GetStatusEffect("Paralyze".GetHashCode()) as SE_Paralyzed;
                 if (seParalyze == null)
                 {
-                    seParalyze = __instance.m_seman.AddStatusEffect("Paralyze") as SE_Paralyzed;
+                    seParalyze = __instance.m_seman.AddStatusEffect("Paralyze".GetHashCode()) as SE_Paralyzed;
                     if (seParalyze == null)
                     {
                         EpicLoot.LogError("Could not add paralyze effect");

--- a/EpicLoot/MagicItemEffects/Slow.cs
+++ b/EpicLoot/MagicItemEffects/Slow.cs
@@ -77,7 +77,7 @@ namespace EpicLoot.MagicItemEffects
 		}
 	}
 
-	[HarmonyPatch(typeof(CharacterAnimEvent), nameof(CharacterAnimEvent.FixedUpdate))]
+	[HarmonyPatch(typeof(CharacterAnimEvent), nameof(CharacterAnimEvent.CustomFixedUpdate))]
 	public static class ModifyEnemyAttackSpeed_CharacterAnimEvent_FixedUpdate_Patch
 	{
 		[UsedImplicitly]

--- a/EpicLoot/Properties/AssemblyInfo.cs
+++ b/EpicLoot/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.9.13")]
-[assembly: AssemblyFileVersion("0.9.13")]
+[assembly: AssemblyVersion("0.9.15")]
+[assembly: AssemblyFileVersion("0.9.15")]

--- a/EpicLoot/Properties/AssemblyInfo.cs
+++ b/EpicLoot/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.9.12")]
-[assembly: AssemblyFileVersion("0.9.12")]
+[assembly: AssemblyVersion("0.9.13")]
+[assembly: AssemblyFileVersion("0.9.13")]

--- a/EpicLoot/VisEquipment_Patch.cs
+++ b/EpicLoot/VisEquipment_Patch.cs
@@ -23,42 +23,42 @@ namespace EpicLoot
 
         public static ItemSettingSlot AttachingItemSlot = ItemSettingSlot.None;
 
-        [HarmonyPatch(typeof(VisEquipment), nameof(VisEquipment.SetLeftHandEquiped))]
+        [HarmonyPatch(typeof(VisEquipment), nameof(VisEquipment.SetLeftHandEquipped))]
         [HarmonyPrefix]
         public static void SetLeftHandEquiped_Prefix()
         {
             AttachingItemSlot = ItemSettingSlot.LeftHand;
         }
 
-        [HarmonyPatch(typeof(VisEquipment), nameof(VisEquipment.SetLeftHandEquiped))]
+        [HarmonyPatch(typeof(VisEquipment), nameof(VisEquipment.SetLeftHandEquipped))]
         [HarmonyPostfix]
         public static void SetLeftHandEquiped_Postfix()
         {
             AttachingItemSlot = ItemSettingSlot.None;
         }
 
-        [HarmonyPatch(typeof(VisEquipment), nameof(VisEquipment.SetRightHandEquiped))]
+        [HarmonyPatch(typeof(VisEquipment), nameof(VisEquipment.SetRightHandEquipped))]
         [HarmonyPrefix]
         public static void SetRightHandEquiped_Prefix()
         {
             AttachingItemSlot = ItemSettingSlot.RightHand;
         }
 
-        [HarmonyPatch(typeof(VisEquipment), nameof(VisEquipment.SetRightHandEquiped))]
+        [HarmonyPatch(typeof(VisEquipment), nameof(VisEquipment.SetRightHandEquipped))]
         [HarmonyPostfix]
         public static void SetRightHandEquiped_Postfix()
         {
             AttachingItemSlot = ItemSettingSlot.None;
         }
 
-        [HarmonyPatch(typeof(VisEquipment), nameof(VisEquipment.SetHelmetEquiped))]
+        [HarmonyPatch(typeof(VisEquipment), nameof(VisEquipment.SetHelmetEquipped))]
         [HarmonyPrefix]
         public static void SetHelmetEquiped_Prefix()
         {
             AttachingItemSlot = ItemSettingSlot.Helmet;
         }
 
-        [HarmonyPatch(typeof(VisEquipment), nameof(VisEquipment.SetLeftHandEquiped))]
+        [HarmonyPatch(typeof(VisEquipment), nameof(VisEquipment.SetLeftHandEquipped))]
         [HarmonyPostfix]
         public static void SetHelmetEquiped_Postfix()
         {
@@ -216,7 +216,7 @@ namespace EpicLoot
         [HarmonyPrefix]
         public static void Humanoid_UnequipItem_Prefix(Humanoid __instance, ItemDrop.ItemData item, bool triggerEquipEffects)
         {
-            if (item == null || !item.m_equiped || !triggerEquipEffects)
+            if (item == null || !item.m_equipped || !triggerEquipEffects)
             {
                 return;
             }

--- a/EpicLoot/enchantcosts.json
+++ b/EpicLoot/enchantcosts.json
@@ -89,52 +89,52 @@
       ]
     },
     {
-      "ItemTypes" : [ "Trophie" ],
+      "ItemTypes" : [ "Trophy" ],
       "ItemNames" : [ "$item_trophy_boar", "$item_trophy_deer", "$item_trophy_greydwarf", "$item_trophy_neck", "$item_trophy_skeleton", "$item_trophy_skeletonpoison" ],
       "Products" : [ { "Item": "ShardMagic", "Amount": 1 } ]
     },
     {
-      "ItemTypes" : [ "Trophie" ],
+      "ItemTypes" : [ "Trophy" ],
       "ItemNames" : [ "$item_trophy_troll", "$item_trophy_greydwarfbrute", "$item_trophy_greydwarfshaman", "$item_trophy_blob", "$item_trophy_draugr", "$item_trophy_draugrelite", "$item_trophy_draugrfem", "$item_trophy_foresttroll", "$item_trophy_leech", "$item_trophy_surtling", "$item_trophy_wolf", "$item_trophy_wraith" ],
       "Products" : [ { "Item": "ShardRare", "Amount": 1 } ]
     },
     {
-      "ItemTypes" : [ "Trophie" ],
+      "ItemTypes" : [ "Trophy" ],
       "ItemNames" : [ "$item_trophy_fenring", "$item_trophy_goblin", "$item_trophy_hatchling", "$item_trophy_lox", "$item_trophy_sgolem", "$item_trophy_abomination", "$item_trophy_cultist", "$item_trophy_ulv", "$item_trophy_growth", "$item_trophy_tick", "$item_trophy_hare" ],
       "Products" : [ { "Item": "ShardEpic", "Amount": 1 } ]
     },
     {
-      "ItemTypes" : [ "Trophie" ],
+      "ItemTypes" : [ "Trophy" ],
       "ItemNames" : [ "$item_trophy_deathsquito", "$item_trophy_goblinbrute", "$item_trophy_goblinshaman", "$item_trophy_serpent", "$item_trophy_seeker", "$item_trophy_seeker_brute", "$item_trophy_gjall", "$item_trophy_dvergr" ],
       "Products" : [ { "Item": "ShardLegendary", "Amount": 1 } ]
     },
     {
-      "ItemTypes" : [ "Trophie" ],
+      "ItemTypes" : [ "Trophy" ],
       "ItemNames" : [ "$item_trophy_eikthyr" ],
       "Products" : [ { "Item": "RunestoneMagic", "Amount": 1 } ]
     },
     {
-      "ItemTypes" : [ "Trophie" ],
+      "ItemTypes" : [ "Trophy" ],
       "ItemNames" : [ "$item_trophy_elder" ],
       "Products" : [ { "Item": "RunestoneRare", "Amount": 1 } ]
     },
     {
-      "ItemTypes" : [ "Trophie" ],
+      "ItemTypes" : [ "Trophy" ],
       "ItemNames" : [ "$item_trophy_bonemass" ],
       "Products" : [ { "Item": "RunestoneEpic", "Amount": 1 } ]
     },
     {
-      "ItemTypes" : [ "Trophie" ],
+      "ItemTypes" : [ "Trophy" ],
       "ItemNames" : [ "$item_trophy_dragonqueen" ],
       "Products" : [ { "Item": "RunestoneLegendary", "Amount": 2 } ]
     },
     {
-      "ItemTypes" : [ "Trophie" ],
+      "ItemTypes" : [ "Trophy" ],
       "ItemNames" : [ "$item_trophy_goblinking" ],
       "Products" : [ { "Item": "RunestoneLegendary", "Amount": 4 } ]
     },
     {
-      "ItemTypes" : [ "Trophie" ],
+      "ItemTypes" : [ "Trophy" ],
       "ItemNames" : [ "$item_trophy_seekerqueen" ],
       "Products" : [ { "Item": "RunestoneLegendary", "Amount": 12 } ]
     },

--- a/EpicLoot/manifest.json
+++ b/EpicLoot/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "EpicLoot",
-  "version_number": "0.9.12",
+  "version_number": "0.9.13",
   "website_url": "https://github.com/RandyKnapp/ValheimMods/wiki/What-is-Epic-Loot%3F",
   "description": "Adds loot drops, magic items, and enchanting to Valheim.",
   "dependencies": [

--- a/EpicLoot/manifest.json
+++ b/EpicLoot/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "EpicLoot",
-  "version_number": "0.9.13",
+  "version_number": "0.9.15",
   "website_url": "https://github.com/RandyKnapp/ValheimMods/wiki/What-is-Epic-Loot%3F",
   "description": "Adds loot drops, magic items, and enchanting to Valheim.",
   "dependencies": [


### PR DESCRIPTION
**Advanced Portals Release 1.0.5 **

```markdown
#### 1.0.5
  * Updated Portal Connection logic which was preventing Advanced Portals from connecting
#### 1.0.4
  * Updates for 0.216.9 Valheim
```

**Epic Loot 0.9.15 Official Release:**

```markdown
## Version 0.9.15 - Valheim Update 0.216.9 - Part 3
* Updated `enchantcosts.json` with the corrected spelling of Trophy (from Trophie).
* Fixed issue with bounties not working correctly after update to 0.9.14.

## Version 0.9.14 - Valheim Update 0.216.9 - Part 2
* Left a piece out that needed to be updated with regards to `CopyCustomDataFromUpgradedItem`
* This fixes the pickable issue with unlimited pickable drops.

## Version 0.9.13 - Valheim Update 0.216.9
* Required updates for Valheim version 0.216.9
```
