### PR TITLE
EpicLoot v0.9.15 and Advanced Portals - PR Take 2

### DIFF
--- a/AdvancedPortals/AdvancedPortals.cs
+++ b/AdvancedPortals/AdvancedPortals.cs
@@ -29,7 +29,7 @@ namespace AdvancedPortals
     {
         public const string PluginId = "randyknapp.mods.advancedportals";
         public const string DisplayName = "Advanced Portals";
-        public const string Version = "1.0.3";
+        public const string Version = "1.0.4";
 
         public static readonly List<GameObject> RegisteredPrefabs = new List<GameObject>();
         public static readonly Dictionary<GameObject, PieceDef> RegisteredPieces = new Dictionary<GameObject, PieceDef>();

--- a/AdvancedPortals/AdvancedPortals.cs
+++ b/AdvancedPortals/AdvancedPortals.cs
@@ -29,7 +29,7 @@ namespace AdvancedPortals
     {
         public const string PluginId = "randyknapp.mods.advancedportals";
         public const string DisplayName = "Advanced Portals";
-        public const string Version = "1.0.4";
+        public const string Version = "1.0.5";
 
         public static readonly List<GameObject> RegisteredPrefabs = new List<GameObject>();
         public static readonly Dictionary<GameObject, PieceDef> RegisteredPieces = new Dictionary<GameObject, PieceDef>();

--- a/AdvancedPortals/ConnectPortals_Patch.cs
+++ b/AdvancedPortals/ConnectPortals_Patch.cs
@@ -24,21 +24,6 @@ namespace AdvancedPortals
             return false;
         }
 
-        [HarmonyPatch(typeof(ZDOMan), nameof(ZDOMan.GetAllZDOsWithPrefab))]
-        [HarmonyPrefix]
-        public static bool GetPortalsZDOs_Prefix(ZDOMan __instance, string prefab, List<ZDO> zdos)
-        {
-            if (Game.instance == null || Game.instance.m_portalPrefab == null || __instance == null)
-                return true;
-
-            var prefabPortalName = Game.instance.m_portalPrefab.name;
-            if (prefab != prefabPortalName)
-                return true;
-
-            GetAllZDOsWithPrefab(__instance, new[] { prefabPortalName, "portal_ancient", "portal_obsidian", "portal_blackmarble" }, zdos);
-            return false;
-        }
-
         public static bool GetAllZDOsWithMultiplePrefabsIterative(ZDOMan __instance, string[] prefabs, List<ZDO> zdos, ref int index)
         {
             var stableHashCode = prefabs.Select(x => x.GetStableHashCode()).ToArray();

--- a/AdvancedPortals/ConnectPortals_Patch.cs
+++ b/AdvancedPortals/ConnectPortals_Patch.cs
@@ -1,91 +1,167 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
+using System.Reflection.Emit;
+using System.Threading;
+using BepInEx;
 using HarmonyLib;
+using JetBrains.Annotations;
+using UnityEngine;
 
 namespace AdvancedPortals
 {
     [HarmonyPatch]
     public static class ConnectPortals_Patch
     {
-        //public bool GetAllZDOsWithPrefabIterative(string prefab, List<ZDO> zdos, ref int index)
-        [HarmonyPatch(typeof(ZDOMan), nameof(ZDOMan.GetAllZDOsWithPrefabIterative))]
-        [HarmonyPrefix]
-        public static bool GetPortalsZDOs_Prefix(ZDOMan __instance, ref bool __result, string prefab, List<ZDO> zdos, ref int index)
+        public static readonly string[] _portalPrefabs = { "portal_ancient", "portal_obsidian", "portal_blackmarble" };
+        public static bool IsPortalPrefabHash(int zdoPrefabHash)
         {
-            if (Game.instance == null || Game.instance.m_portalPrefab == null || __instance == null)
-                return true;
-
-            var prefabPortalName = Game.instance.m_portalPrefab.name;
-            if (prefab != prefabPortalName)
-                return true;
-
-            __result = GetAllZDOsWithMultiplePrefabsIterative(__instance, new []{ prefabPortalName, "portal_ancient", "portal_obsidian", "portal_blackmarble" }, zdos, ref index);
-            return false;
+            return IsPortalPrefabHash(zdoPrefabHash, true);
         }
 
-        public static bool GetAllZDOsWithMultiplePrefabsIterative(ZDOMan __instance, string[] prefabs, List<ZDO> zdos, ref int index)
+        public static bool IsPortalPrefabHash(int zdoPrefabHash, bool checkDefaultHash)
         {
-            var stableHashCode = prefabs.Select(x => x.GetStableHashCode()).ToArray();
-            if (index >= __instance.m_objectsBySector.Length)
-            {
-                foreach (var zdoList in __instance.m_objectsByOutsideSector.Values)
-                {
-                    foreach (var zdo in zdoList)
-                    {
-                        foreach (var nameHash in stableHashCode)
-                        {
-                            if (zdo.GetPrefab() == nameHash)
-                            {
-                                zdos.Add(zdo);
-                                break;
-                            }
-                        }
-                    }
-                }
-                zdos.RemoveAll(new Predicate<ZDO>(ZDOMan.InvalidZDO));
+            if (checkDefaultHash && (zdoPrefabHash == Game.instance.PortalPrefabHash))
                 return true;
-            }
-            var num = 0;
-            while (index < __instance.m_objectsBySector.Length)
-            {
-                var zdoList = __instance.m_objectsBySector[index];
-                if (zdoList != null)
-                {
-                    foreach (var zdo in zdoList)
-                    {
-                        foreach (var nameHash in stableHashCode)
-                        {
-                            if (zdo.GetPrefab() == nameHash)
-                            {
-                                zdos.Add(zdo);
-                                break;
-                            }
-                        }
-                    }
-                    ++num;
-                    if (num > 400)
-                        break;
-                }
-                ++index;
-            }
-            return false;
+            
+            var stableHashCodes = _portalPrefabs.Select(x => x.GetStableHashCode()).ToArray();
+
+            return stableHashCodes.Any(x => x.GetHashCode() == zdoPrefabHash);
         }
 
-        public static void GetAllZDOsWithPrefab(ZDOMan __instance, string[] prefabs, List<ZDO> zdos)
+        //Step 1:
+        //Need to Transpile ZDOMan.Load()
+        [HarmonyPatch(typeof(ZDOMan), nameof(ZDOMan.Load))]
+        static class ConnectPortalsTranspiler
         {
-            var stableHashCode = prefabs.Select(x => x.GetStableHashCode()).ToArray();
-            foreach (ZDO zdo in __instance.m_objectsByID.Values)
+            [UsedImplicitly]
+            public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator ilGenerator)
             {
-                foreach (var nameHash in stableHashCode)
+                var instrs = instructions.ToList();
+
+                var counter = 0;
+
+                CodeInstruction LogMessage(CodeInstruction instruction)
                 {
-                    if (zdo.GetPrefab() == nameHash)
+                    if (Debug.isDebugBuild)
                     {
-                        zdos.Add(zdo);
-                        break;
+                        Debug.Log($"IL_{counter}: Opcode: {instruction.opcode} Operand: {instruction.operand} Labels: {instruction.labels.Count}");                        
+                    }
+                    return instruction;
+                }
+
+                var portalPrefabHashMethod = AccessTools.PropertyGetter(typeof(Game), nameof(Game.PortalPrefabHash));
+                var gameInstanceMethod = AccessTools.PropertyGetter(typeof(Game), nameof(Game.instance));
+                var isPortalPrefabMethod = AccessTools.DeclaredMethod(typeof(ConnectPortals_Patch),
+                    nameof(IsPortalPrefabHash), new[] { typeof(int) });
+
+                var zLogLabel = ilGenerator.DefineLabel();
+                
+                for (int i = 0; i < instrs.Count; ++i)
+                {
+                    
+                    if (i > 6 && instrs[i].opcode == OpCodes.Call && instrs[i].operand.Equals(gameInstanceMethod)
+                        && instrs[i + 1].opcode == OpCodes.Callvirt &&
+                        instrs[i + 1].operand.Equals(portalPrefabHashMethod) &&
+                        instrs[i + 2].opcode == OpCodes.Bne_Un)
+                    {
+
+                        //Need to change zdo.GetPrefab() == Game.instance.PortalPrefabHash to IsPortalPrefabHash(zdo.GetPrefab())
+
+                        //Call IsPortalPrefab Method
+                        var callInstruction = new CodeInstruction(OpCodes.Call, isPortalPrefabMethod);
+                        //Move Any Labels from the instruction position being patched to new instruction.
+                        if (instrs[i].labels.Count > 0)
+                            instrs[i].MoveLabelsTo(callInstruction);
+
+                        yield return LogMessage(callInstruction);
+                        counter++;
+                        
+                        //Need to change bne.un to a brfalse
+                        var brfalseInstruction = new CodeInstruction(OpCodes.Brfalse, instrs[i + 2].operand);
+                        yield return LogMessage(brfalseInstruction);
+                        counter++;
+
+                        //Advance to overwrite original instructions.
+                        i += 2;
+                    }
+                    else if (i > 6 && instrs[i].opcode == OpCodes.Ldloc_3 && 
+                             instrs[i + 1].opcode == OpCodes.Ldarg_1 && 
+                             instrs[i + 2].opcode == OpCodes.Callvirt &&
+                             instrs[i + 2].operand.Equals(AccessTools.Method(typeof(ZPackage), nameof(ZPackage.SetReader))))
+                    {
+                        //Read Ldarg2
+                        var ldArgInstruction = new CodeInstruction(OpCodes.Ldarg_2);
+                        //Move Any Labels from the instruction position being patched to new instruction.
+                        if (instrs[i].labels.Count > 0)
+                            instrs[i].MoveLabelsTo(ldArgInstruction);
+                            
+                        yield return LogMessage(ldArgInstruction);
+                        counter++;
+                        
+                        //Read ldc_I4
+                        yield return LogMessage(new CodeInstruction(OpCodes.Ldc_I4, 31));
+                        counter++;
+
+                        //If ldArg2 is less than idc_I4 of 31, go to new label.
+                        yield return LogMessage(new CodeInstruction(OpCodes.Blt, zLogLabel));
+                        counter++;
+                        
+                        //Add original instruction
+                        yield return LogMessage(instrs[i]);
+                        counter++;
+
+                    } else if (i > 6 && instrs[i].opcode == OpCodes.Ldstr && instrs[i].operand.Equals("Adding to Dictionary"))
+                    {
+                        //Add new label to ZLog instruction
+                        instrs[i].labels.Add(zLogLabel);
+                        yield return LogMessage(instrs[i]);
+                        counter++;
+                    }
+                    else
+                    {
+                        yield return LogMessage(instrs[i]);
+                        counter++;
                     }
                 }
             }
         }
+
+        //Step 2:
+        //Need to Postfix ZDOMan private ZDO CreateNewZDO(ZDOID uid, Vector3 position, int prefabHashIn = 0)
+        [HarmonyPatch(typeof(ZDOMan), nameof(ZDOMan.CreateNewZDO),new[] { typeof(ZDOID), typeof(Vector3), typeof(int) })]
+        static class ZDOManCreateNewZDOPatch
+        {
+            [UsedImplicitly]
+            static void Postfix(ZDOMan __instance, ZDO __result, ZDOID uid, Vector3 position, int prefabHashIn = 0)
+            {
+                //If newZdo.GetPrefab() or prefabHashIn IsPortalPrefabHash() add to portalObjects
+                if (IsPortalPrefabHash(prefabHashIn != 0 ? prefabHashIn : __result.GetPrefab(), false))
+                {
+                    if (!__instance.m_portalObjects.Contains(__result)) 
+                        __instance.m_portalObjects.Add(__result);
+                }
+            }
+        }        
+        
+        //Step 3:
+        //Need to Prefix ZDOMan HandleDestroyedZDO(ZDOID uid)
+        [HarmonyPatch(typeof(ZDOMan), nameof(ZDOMan.HandleDestroyedZDO),new[] { typeof(ZDOID) })]
+        static class ZDOManHandleDestroyedZDOPatch
+        {
+            [UsedImplicitly]
+            static void Prefix(ZDOMan __instance, ZDOID uid)
+            {
+                //if IsPortalPrefabHash(zdo.GetPrefab()) true, remove from portalObjects
+                var zdo = __instance.GetZDO(uid);
+                if (zdo == null)
+                    return;
+
+                if (IsPortalPrefabHash(zdo.GetPrefab()))
+                {
+                    if (__instance.m_portalObjects.Contains(zdo))
+                        __instance.m_portalObjects.Remove(zdo); 
+                }
+            }
+        }        
     }
 }

--- a/AdvancedPortals/Properties/AssemblyInfo.cs
+++ b/AdvancedPortals/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.4")]
-[assembly: AssemblyFileVersion("1.0.4")]
+[assembly: AssemblyVersion("1.0.5")]
+[assembly: AssemblyFileVersion("1.0.5")]

--- a/AdvancedPortals/Properties/AssemblyInfo.cs
+++ b/AdvancedPortals/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.3")]
-[assembly: AssemblyFileVersion("1.0.3")]
+[assembly: AssemblyVersion("1.0.4")]
+[assembly: AssemblyFileVersion("1.0.4")]

--- a/AdvancedPortals/README.md
+++ b/AdvancedPortals/README.md
@@ -1,4 +1,4 @@
-# AdvancedPortals v1.0.3
+# AdvancedPortals v1.0.4
 Author: RandyKnapp
 Source: [Github](https://github.com/RandyKnapp/ValheimMods/tree/main/AdvancedPortals)
 Discord: [RandyKnapp's Mod Community](https://discord.gg/randyknappmods)
@@ -46,6 +46,8 @@ Includes ServerSync.
 
 ### Changelist:
 
+#### 1.0.4
+  * Updates for Valheim 0.216.7 
 #### 1.0.3
   * Vapok fixed a bug that makes Adventure Backpacks work with Advanced Portals
 #### 1.0.2

--- a/AdvancedPortals/README.md
+++ b/AdvancedPortals/README.md
@@ -46,8 +46,10 @@ Includes ServerSync.
 
 ### Changelist:
 
-#### 1.0.4
-  * Updates for Valheim 0.216.7 
+#### 1.0.5
+  * Updated Portal Connection logic which was preventing Advanced Portals from connecting
+#### 1.0.4 
+  * Updates for Valheim 0.216.9
 #### 1.0.3
   * Vapok fixed a bug that makes Adventure Backpacks work with Advanced Portals
 #### 1.0.2

--- a/AdvancedPortals/manifest.json
+++ b/AdvancedPortals/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "AdvancedPortals",
-  "version_number": "1.0.3",
+  "version_number": "1.0.4",
   "website_url": "https://github.com/RandyKnapp/ValheimMods/tree/main/AdvancedPortals",
   "description": "Add new, lore-friendly and balanced portals to allow some items to be teleported.",
   "dependencies": []

--- a/AdvancedPortals/manifest.json
+++ b/AdvancedPortals/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "AdvancedPortals",
-  "version_number": "1.0.4",
+  "version_number": "1.0.5",
   "website_url": "https://github.com/RandyKnapp/ValheimMods/tree/main/AdvancedPortals",
   "description": "Add new, lore-friendly and balanced portals to allow some items to be teleported.",
   "dependencies": []

--- a/CreatureLevelAndLootControl/API.cs
+++ b/CreatureLevelAndLootControl/API.cs
@@ -1,0 +1,105 @@
+﻿using HarmonyLib;
+using System.Reflection;
+using System.Reflection.Emit;
+
+
+#nullable enable
+namespace CreatureLevelControl
+{
+  public static class API
+  {
+    private static readonly Assembly? targetAssembly;
+
+    static API()
+    {
+      if (!((API.targetAssembly = API.LoadAssembly()) != (Assembly) null))
+        return;
+      Harmony harmony = new Harmony("org.bepinex.plugins.creaturelevelcontrol.API");
+      foreach (MethodInfo original in ((IEnumerable<MethodInfo>) typeof (API).GetMethods(BindingFlags.DeclaredOnly | BindingFlags.Static | BindingFlags.Public)).Where<MethodInfo>((Func<MethodInfo, bool>) (m => m.Name != "IsLoaded" && m.Name != "LoadAssembly")))
+        harmony.Patch((MethodBase) original, transpiler: new HarmonyMethod(AccessTools.DeclaredMethod(typeof (API), "transpiler")));
+    }
+
+    private static IEnumerable<CodeInstruction> transpiler(
+      IEnumerable<CodeInstruction> _,
+      MethodBase original)
+    {
+      System.Type[] parameters = ((IEnumerable<ParameterInfo>) original.GetParameters()).Select<ParameterInfo, System.Type>((Func<ParameterInfo, System.Type>) (p =>
+      {
+        System.Type type = p.ParameterType;
+        if (type.Assembly == Assembly.GetExecutingAssembly())
+          type = API.targetAssembly.GetType(type.FullName);
+        return type;
+      })).ToArray<System.Type>();
+      MethodBase originalMethod = (MethodBase) API.targetAssembly.GetType("CreatureLevelControl.API").GetMethod(original.Name, parameters);
+      for (int i = 0; i < parameters.Length; ++i)
+        yield return new CodeInstruction(OpCodes.Ldarg, (object) i);
+      yield return new CodeInstruction(OpCodes.Call, (object) originalMethod);
+      yield return new CodeInstruction(OpCodes.Ret);
+    }
+
+    public static Assembly? LoadAssembly() => ((IEnumerable<Assembly>) AppDomain.CurrentDomain.GetAssemblies()).SingleOrDefault<Assembly>((Func<Assembly, bool>) (a => a.GetName().Name == "CreatureLevelControl"));
+
+    public static bool IsLoaded() => API.LoadAssembly() != (Assembly) null;
+
+    public static bool IsEnabled() => false;
+
+    public static bool IsInfusionEnabled() => false;
+
+    public static bool IsExtraEffectEnabled() => false;
+
+    public static bool IsAffixEnabled() => false;
+
+    public static int GetWorldLevel() => 0;
+
+    public static float[] LevelProbabilities(
+      Character? character,
+      int worldLevel,
+      bool includeZoneBonusLevel)
+    {
+      return new float[3]{ 89f, 10f, 1f };
+    }
+
+    public static int LevelRand(Character character)
+    {
+      if (character.IsBoss() || UnityEngine.Random.Range(0, 10) != 0)
+        return 1;
+      return UnityEngine.Random.Range(0, 10) != 0 ? 2 : 3;
+    }
+
+    public static bool HasAffixBoss(Character character) => false;
+
+    public static BossAffix GetAffixBoss(Character character) => BossAffix.None;
+
+    public static void SetAffixBoss(Character character, BossAffix affix)
+    {
+    }
+
+    public static bool HasExtraEffectCreature(Character character) => false;
+
+    public static CreatureExtraEffect GetExtraEffectCreature(Character character) => CreatureExtraEffect.None;
+
+    public static void SetExtraEffectCreature(Character character)
+    {
+    }
+
+    public static void SetExtraEffectCreature(Character character, CreatureExtraEffect effect)
+    {
+    }
+
+    public static bool HasInfusionCreature(Character character) => false;
+
+    public static CreatureInfusion GetInfusionCreature(Character character) => CreatureInfusion.None;
+
+    public static void SetInfusionCreature(Character character)
+    {
+    }
+
+    public static void SetInfusionCreature(Character character, CreatureInfusion infusion)
+    {
+    }
+
+    public static Character? GetTwinBoss(Character boss) => (Character) null;
+
+    public static bool DropItemOnDeath(ItemDrop.ItemData item) => !item.m_shared.m_questItem && !item.m_equipped;
+  }
+}

--- a/CreatureLevelAndLootControl/CreatureLevelAndLootControl.csproj
+++ b/CreatureLevelAndLootControl/CreatureLevelAndLootControl.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>disable</Nullable>
+        <AssemblyName>CreatureLevelControlAPI</AssemblyName>
+        <RootNamespace>CreatureLevelControl</RootNamespace>
+        <LangVersion>latestmajor</LangVersion>
+        <TargetFrameworks>net461;net462</TargetFrameworks>
+    </PropertyGroup>
+    <ItemGroup>
+        <Reference Include="0Harmony">
+            <HintPath>M:\Code\VapokModBase\References\BepInEx\5.4.2101\BepInEx\core\0Harmony.dll</HintPath>
+        </Reference>
+        <Reference Include="assembly_guiutils_publicized">
+            <HintPath>M:\Code\VapokModBase\References\Valheim\0.216.8\assembly_guiutils_publicized.dll</HintPath>
+        </Reference>
+        <Reference Include="assembly_utils_publicized">
+            <HintPath>M:\Code\VapokModBase\References\Valheim\0.216.8\assembly_utils_publicized.dll</HintPath>
+        </Reference>
+        <Reference Include="assembly_valheim_publicized">
+            <HintPath>M:\Code\VapokModBase\References\Valheim\0.216.8\assembly_valheim_publicized.dll</HintPath>
+        </Reference>
+        <Reference Include="CreatureLevelControl">
+          <HintPath>..\..\VapokModBase\References\CLLC\CreatureLevelControl.dll</HintPath>
+        </Reference>
+        <Reference Include="System.Net" />
+        <Reference Include="System.Net.Http" />
+        <Reference Include="UnityEngine">
+            <HintPath>M:\Code\VapokModBase\References\BepInEx\5.4.2101\unstripped_corlib\UnityEngine.dll</HintPath>
+        </Reference>
+        <Reference Include="UnityEngine.CoreModule">
+            <HintPath>M:\Code\VapokModBase\References\BepInEx\5.4.2101\unstripped_corlib\UnityEngine.CoreModule.dll</HintPath>
+        </Reference>
+    </ItemGroup>
+</Project>

--- a/EpicLoot/Data/CustomDataManager.cs
+++ b/EpicLoot/Data/CustomDataManager.cs
@@ -630,6 +630,11 @@ namespace EpicLoot.Data
 				ZDO? zdo = netView && netView.IsValid() ? netView.GetZDO() : null;
 				if (zdo == null) return;
 				
+				if (!ZDOExtraData.s_ints.ContainsKey(zdo.m_uid))
+				{
+					ZDOExtraData.s_ints.Add(zdo.m_uid,new BinarySearchDictionary<int, int>());
+				}
+				
 				var containsDataCount = ZDOExtraData.s_ints[zdo.m_uid].ContainsKey("dataCount".GetStableHashCode());
 				
 				if (containsDataCount != true)

--- a/EpicLoot/MagicItemComponent.cs
+++ b/EpicLoot/MagicItemComponent.cs
@@ -915,10 +915,10 @@ namespace EpicLoot
                 return instruction;
             }
 
-            var elementDataEquipedField = AccessTools.DeclaredField(typeof(HotkeyBar.ElementData), "m_equiped"); 
-            var itemDataEquipedField = AccessTools.DeclaredField(typeof(ItemDrop.ItemData), "m_equiped");
+            var elementDataEquipedField = AccessTools.DeclaredField(typeof(HotkeyBar.ElementData), nameof(HotkeyBar.ElementData.m_equiped)); 
+            var itemDataEquipedField = AccessTools.DeclaredField(typeof(ItemDrop.ItemData), nameof(ItemDrop.ItemData.m_equipped));
             var setActiveMethod = AccessTools.DeclaredMethod(typeof(GameObject), nameof(GameObject.SetActive));
-            var elementUsedField = AccessTools.DeclaredField(typeof(HotkeyBar.ElementData), "m_used"); 
+            var elementUsedField = AccessTools.DeclaredField(typeof(HotkeyBar.ElementData), nameof(HotkeyBar.ElementData.m_used)); 
 
             for (int i = 0; i < instrs.Count; ++i)
             {

--- a/EpicLoot/MagicItemEffects/Waterproof.cs
+++ b/EpicLoot/MagicItemEffects/Waterproof.cs
@@ -22,12 +22,12 @@ namespace EpicLoot.MagicItemEffects
             }
         }
 
-        [HarmonyPatch(typeof(SEMan), nameof(SEMan.AddStatusEffect), typeof(string), typeof(bool), typeof(int), typeof(float))]
+        [HarmonyPatch(typeof(SEMan), nameof(SEMan.AddStatusEffect), typeof(int), typeof(bool), typeof(int), typeof(float))]
         public static class Waterproof_SEMan_AddStatusEffect_Patch
         {
-            public static bool Prefix(SEMan __instance, string name)
+            public static bool Prefix(SEMan __instance, int name)
             {
-                if (AddingStatusFromEnv > 0 && __instance.m_character.IsPlayer() && name == "Wet")
+                if (AddingStatusFromEnv > 0 && __instance.m_character.IsPlayer() && name == "Wet".GetHashCode())
                 {
                     var player = (Player) __instance.m_character;
                     var hasWaterproofEquipment = player.HasActiveMagicEffect(MagicEffectType.Waterproof);

--- a/EpicLoot/MagicItemEffects/Waterproof.cs
+++ b/EpicLoot/MagicItemEffects/Waterproof.cs
@@ -25,9 +25,9 @@ namespace EpicLoot.MagicItemEffects
         [HarmonyPatch(typeof(SEMan), nameof(SEMan.AddStatusEffect), typeof(int), typeof(bool), typeof(int), typeof(float))]
         public static class Waterproof_SEMan_AddStatusEffect_Patch
         {
-            public static bool Prefix(SEMan __instance, int name)
+            public static bool Prefix(SEMan __instance, int nameHash)
             {
-                if (AddingStatusFromEnv > 0 && __instance.m_character.IsPlayer() && name == "Wet".GetHashCode())
+                if (AddingStatusFromEnv > 0 && __instance.m_character.IsPlayer() && nameHash == "Wet".GetHashCode())
                 {
                     var player = (Player) __instance.m_character;
                     var hasWaterproofEquipment = player.HasActiveMagicEffect(MagicEffectType.Waterproof);

--- a/ValheimMods.sln
+++ b/ValheimMods.sln
@@ -35,6 +35,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AdvancedPortals", "Advanced
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EpicLoot-Addon-AddonTest", "EpicLoot-Addon-AddonTest\EpicLoot-Addon-AddonTest.csproj", "{3F98C47A-5899-40DF-AA2A-1097A2290D62}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CreatureLevelAndLootControl", "CreatureLevelAndLootControl\CreatureLevelAndLootControl.csproj", "{39F2EDDE-D0CA-4CAD-8C51-5DBDF52A419A}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		Common\Common.projitems*{08ed5bc9-9e0c-4343-90a5-92497be6e216}*SharedItemsImports = 4
@@ -104,6 +106,10 @@ Global
 		{3F98C47A-5899-40DF-AA2A-1097A2290D62}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3F98C47A-5899-40DF-AA2A-1097A2290D62}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3F98C47A-5899-40DF-AA2A-1097A2290D62}.Release|Any CPU.Build.0 = Release|Any CPU
+		{39F2EDDE-D0CA-4CAD-8C51-5DBDF52A419A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{39F2EDDE-D0CA-4CAD-8C51-5DBDF52A419A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{39F2EDDE-D0CA-4CAD-8C51-5DBDF52A419A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{39F2EDDE-D0CA-4CAD-8C51-5DBDF52A419A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
**Advanced Portals Release 1.0.5 **

```markdown
#### 1.0.5
  * Updated Portal Connection logic which was preventing Advanced Portals from connecting
#### 1.0.4
  * Updates for 0.216.9 Valheim
```

**Epic Loot 0.9.15 Official Release:**

```markdown
## Version 0.9.15 - Valheim Update 0.216.9 - Part 3
* Updated `enchantcosts.json` with the corrected spelling of Trophy (from Trophie).
* Fixed issue with bounties not working correctly after update to 0.9.14.

## Version 0.9.14 - Valheim Update 0.216.9 - Part 2
* Left a piece out that needed to be updated with regards to `CopyCustomDataFromUpgradedItem`
* This fixes the pickable issue with unlimited pickable drops.

## Version 0.9.13 - Valheim Update 0.216.9
* Required updates for Valheim version 0.216.9
```
