### PR TITLE
Update TextsDialog_Patch.cs

### DIFF
--- a/EpicLoot/TextsDialog_Patch.cs
+++ b/EpicLoot/TextsDialog_Patch.cs
@@ -214,7 +214,11 @@ namespace EpicLoot
 
             for (var i = 0; i < TextContainer.childCount; i++)
             {
-                Object.Destroy(TextContainer.GetChild(i).gameObject);
+                var child = TextContainer.GetChild(i);
+                if (child != __instance.m_textArea.transform)
+                {
+                    Object.Destroy(child.gameObject);
+                }
             }
 
             var description = Object.Instantiate(TitleTextPrefab, TextContainer);


### PR DESCRIPTION
This code will destroy all child objects of the TextContainer. If m_textArea is one of the child objects of the TextContainer and is being used when the child objects are being destroyed, it will cause m_textArea to become null. This can result in other mods being unable to access the m_textArea object.