### PR TITLE
Epic Loot 0.9.23 - Crafting with Enchanted Components

### DIFF
--- a/EpicLoot/CHANGELOG.md
+++ b/EpicLoot/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Version 0.9.23 - Crafting with Enchanted Components
 * Recipes built with items that are Enchanted will now carry over their magical properties to the new item.
+    * The highest magical rarity will carry over if more than one magical item is consumed.
 * Server-Synced Configuration is available toggle the enablement of this functionality.
-  * Default will leave this functionality Disabled.
+    * Default will leave this functionality Disabled.
 
 ## Version 0.9.22 - Bounty System Improvements Part 2
 * Would help if I included the translations in the Module Zip

--- a/EpicLoot/CHANGELOG.md
+++ b/EpicLoot/CHANGELOG.md
@@ -1,6 +1,11 @@
+## Version 0.9.23 - Crafting with Enchanted Components
+* Recipes built with items that are Enchanted will now carry over their magical properties to the new item.
+* Server-Synced Configuration is available toggle the enablement of this functionality.
+  * Default will leave this functionality Disabled.
+
 ## Version 0.9.22 - Bounty System Improvements Part 2
 * Would help if I included the translations in the Module Zip
-  * Also, when Auga is NOT installed, have to forcably localize the strings.
+    * Also, when Auga is NOT installed, have to forcably localize the strings.
 * Added the new trophies to the Enchantcosts
 
 ## Version 0.9.21 - Bounty System Improvements

--- a/EpicLoot/Crafting/TransferMagicalEffects.cs
+++ b/EpicLoot/Crafting/TransferMagicalEffects.cs
@@ -1,0 +1,107 @@
+﻿using System.Collections.Generic;
+using HarmonyLib;
+using JetBrains.Annotations;
+using UnityEngine;
+
+namespace EpicLoot.Crafting;
+
+public static class TransferMagicalEffects
+{
+
+    private static bool IsDoCraft;
+    private static ItemDrop.ItemData CraftedItem = null;
+    private static List<ItemDrop.ItemData> ConsumedMagicItems = new ();
+
+    private static void TransferMagicToCraftedItem(Player player)
+    {
+        if (!IsDoCraft || !EpicLoot.TransferMagicItemToCrafts.Value || CraftedItem == null || ConsumedMagicItems.Count == 0) return;
+
+        MagicItem highestTierMagicItem =  null;
+        
+        foreach (var itemData in ConsumedMagicItems)
+        {
+            var magicItem = itemData.GetMagicItem();
+            if (magicItem == null)
+                continue;
+            if (highestTierMagicItem == null)
+                highestTierMagicItem = magicItem;
+            else
+            {
+                if (magicItem.Rarity > highestTierMagicItem.Rarity)
+                    highestTierMagicItem = magicItem;
+                else if (magicItem.Rarity == highestTierMagicItem.Rarity)
+                    if (magicItem.Effects.Count > highestTierMagicItem.Effects.Count)
+                        highestTierMagicItem = magicItem;
+            }
+        }
+
+        if (highestTierMagicItem == null)
+            return;
+
+        IsDoCraft = false;
+        CraftedItem.SaveMagicItem(highestTierMagicItem);
+    }
+    
+    [HarmonyPatch(typeof(InventoryGui), nameof(InventoryGui.DoCrafting))]
+    static class InventoryGuiDoCraftingPatch
+    {
+        [UsedImplicitly]
+        static void Prefix(InventoryGui __instance)
+        {
+            IsDoCraft = true;
+        }
+
+        [UsedImplicitly]
+        static void Postfix(InventoryGui __instance, Player player)
+        {
+            TransferMagicToCraftedItem(player);
+            IsDoCraft = false;
+            CraftedItem = null;
+            ConsumedMagicItems = new List<ItemDrop.ItemData>();
+        }
+    }
+
+    [HarmonyPatch(typeof(Inventory), nameof(Inventory.AddItem), new []{typeof(string), typeof(int), typeof(int), typeof(int), typeof(long),typeof(string),typeof(bool)})]
+    static class InventoryAddItemPatch
+    {
+        [UsedImplicitly]
+        static void Postfix(Inventory __instance, ref ItemDrop.ItemData __result)
+        {
+            if (!IsDoCraft) return;
+            
+            CraftedItem = __result;
+        }
+    }
+
+    [HarmonyPatch(typeof(Inventory), nameof(Inventory.RemoveItem), new[] { typeof(string), typeof(int), typeof(int), typeof(bool) })]
+    static class InventoryRemoveItemPatch
+    {
+        private static void CheckConsumedResource(ItemDrop.ItemData itemData)
+        {
+            if (!IsDoCraft) return;
+            
+            if (itemData.IsMagic())
+                ConsumedMagicItems.Add(itemData);
+        }
+
+        [UsedImplicitly]
+        public static void Prefix(Inventory __instance, string name, int amount, int itemQuality, bool worldLevelBased)
+        {
+            if (!IsDoCraft || __instance == null) return;
+
+            foreach (var itemData in __instance.m_inventory)
+            {
+                if (itemData.m_shared.m_name == name 
+                    && (itemQuality < 0 || itemData.m_quality == itemQuality) 
+                    && (!worldLevelBased || itemData.m_worldLevel >= Game.m_worldLevel))
+                {
+                    var num = Mathf.Min(itemData.m_stack, amount);
+                    amount -= num;
+                    if (amount > 0) continue;
+                    CheckConsumedResource(itemData);
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/EpicLoot/EpicLoot.cs
+++ b/EpicLoot/EpicLoot.cs
@@ -89,9 +89,9 @@ namespace EpicLoot
     {
         public const string PluginId = "randyknapp.mods.epicloot";
         public const string DisplayName = "Epic Loot";
-        public const string Version = "0.9.22";
+        public const string Version = "0.9.23";
 
-        private readonly ConfigSync _configSync = new ConfigSync(PluginId) { DisplayName = DisplayName, CurrentVersion = Version, MinimumRequiredVersion = "0.9.22" };
+        private readonly ConfigSync _configSync = new ConfigSync(PluginId) { DisplayName = DisplayName, CurrentVersion = Version, MinimumRequiredVersion = "0.9.23" };
 
         private static ConfigEntry<string> _setItemColor;
         private static ConfigEntry<string> _magicRarityColor;
@@ -107,6 +107,7 @@ namespace EpicLoot
         // TODO: Mythic Hookup
         //private static ConfigEntry<int> _mythicMaterialIconColor;
         public static ConfigEntry<bool> UseScrollingCraftDescription;
+        public static ConfigEntry<bool> TransferMagicItemToCrafts;
         public static ConfigEntry<CraftingTabStyle> CraftingTabStyle;
         private static ConfigEntry<bool> _loggingEnabled;
         private static ConfigEntry<LogLevel> _logLevel;
@@ -220,6 +221,7 @@ namespace EpicLoot
             SetItemDropChance = SyncedConfig("Balance", "Set Item Drop Chance", 0.15f, "The percent chance that a legendary item will be a set item. Min = 0, Max = 1");
             GlobalDropRateModifier = SyncedConfig("Balance", "Global Drop Rate Modifier", 1.0f, "A global percentage that modifies how likely items are to drop. 1 = Exactly what is in the loot tables will drop. 0 = Nothing will drop. 2 = The number of items in the drop table are twice as likely to drop (note, this doesn't double the number of items dropped, just doubles the relative chance for them to drop). Min = 0, Max = 4");
             ItemsToMaterialsDropRatio = SyncedConfig("Balance", "Items To Materials Drop Ratio", 0.0f, "Sets the chance that item drops are instead dropped as magic crafting materials. 0 = all items, no materials. 1 = all materials, no items. Values between 0 and 1 change the ratio of items to materials that drop. At 0.5, half of everything that drops would be items and the other half would be materials. Min = 0, Max = 1");
+            TransferMagicItemToCrafts = SyncedConfig("Balance", "Transfer Enchants to Crafted Items", false, "When enchanted items are used as ingredients in recipes, transfer the highest enchant to the newly crafted item. Default: False.");
 
             AlwaysShowWelcomeMessage = Config.Bind("Debug", "AlwaysShowWelcomeMessage", false, "Just a debug flag for testing the welcome message, do not use.");
             OutputPatchedConfigFiles = Config.Bind("Debug", "OutputPatchedConfigFiles", false, "Just a debug flag for testing the patching system, do not use.");

--- a/EpicLoot/EpicLoot.csproj
+++ b/EpicLoot/EpicLoot.csproj
@@ -132,6 +132,7 @@
     <Compile Include="Crafting\AugmentHelper.cs" />
     <Compile Include="Crafting\CraftSuccessDialog.cs" />
     <Compile Include="Crafting\EnchantHelper.cs" />
+    <Compile Include="Crafting\TransferMagicalEffects.cs" />
     <Compile Include="Data\ConfigValue.cs" />
     <Compile Include="Data\EIDFLegacy.cs" />
     <Compile Include="Data\CustomDataManager.cs" />

--- a/EpicLoot/Properties/AssemblyInfo.cs
+++ b/EpicLoot/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.9.22")]
-[assembly: AssemblyFileVersion("0.9.22")]
+[assembly: AssemblyVersion("0.9.23")]
+[assembly: AssemblyFileVersion("0.9.23")]

--- a/EpicLoot/manifest.json
+++ b/EpicLoot/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "EpicLoot",
-  "version_number": "0.9.22",
+  "version_number": "0.9.23",
   "website_url": "https://github.com/RandyKnapp/ValheimMods/wiki/What-is-Epic-Loot%3F",
   "description": "Adds loot drops, magic items, and enchanting to Valheim.",
   "dependencies": [


### PR DESCRIPTION
## Version 0.9.23 - Crafting with Enchanted Components
* Recipes built with items that are Enchanted will now carry over their magical properties to the new item.
    * The highest magical rarity will carry over if more than one magical item is consumed.
* Server-Synced Configuration is available toggle the enablement of this functionality.
  * Default will leave this functionality Disabled.